### PR TITLE
fix site ordering

### DIFF
--- a/lib/EaRydLattices/src/lattice.jl
+++ b/lib/EaRydLattices/src/lattice.jl
@@ -93,8 +93,10 @@ function make_grid(sites::AbstractVector{NTuple{1, T}}; atol=10*eps(T)) where {T
 end
 padydim(x::Tuple{T}) where T = (x[1], zero(T))
 function make_grid(sites::AbstractVector{NTuple{2, T}}; atol=10*eps(T)) where {T}
-    xs, ixs = approximate_unique(getindex.(sites, 1), atol)
-    ys, iys = approximate_unique(getindex.(sites, 2), atol)
+    xs = sort!(approximate_unique(getindex.(sites, 1), atol))
+    ys = sort!(approximate_unique(getindex.(sites, 2), atol))
+    ixs = map(s->findfirst(==(s[1]), xs), sites)
+    iys = map(s->findfirst(==(s[2]), ys), sites)
     m, n = length(xs), length(ys)
     mask = zeros(Bool, m, n)
     for (ix, iy) in zip(ixs, iys)
@@ -106,22 +108,19 @@ end
 # return `(uxs, ixs)``, where `uxs` is the unique x-coordinates, `ixs` the mapping from the index in `xs` to the index in `uxs`.
 function approximate_unique(xs::AbstractVector{T}, atol) where T
     uxs = T[]
-    ixs = Vector{Int}(undef, length(xs))
-    for (i, x) in enumerate(xs)
+    for x in xs
         found = false
-        for (k, ux) in enumerate(uxs)
+        for ux in uxs
             if isapprox(x, ux; atol=atol)
-                ixs[i] = k
                 found = true
                 break
             end
         end
         if !found
             push!(uxs, x)
-            ixs[i] = length(uxs)
         end
     end
-    return uxs, ixs
+    return uxs
 end
 
 # get locations in order
@@ -132,4 +131,3 @@ end
 # TODO
 # pseudo-lattices,
 # image/svg output (maybe),
-# use KDTree.

--- a/lib/EaRydLattices/test/runtests.jl
+++ b/lib/EaRydLattices/test/runtests.jl
@@ -38,3 +38,12 @@ end
         @test length(gn[10]) == 0
     end
 end
+
+@testset "fix site ordering" begin
+    lt = generate_sites(KagomeLattice(), 5, 5)
+    grd = make_grid(lt[2:end-1])
+    x, y = locations(grd)[1]
+    @test issorted(grd.xs)
+    @test issorted(grd.ys)
+    @test x ≈ 1.0 && y ≈ 0.0
+end


### PR DESCRIPTION
fix #48 

```julia
julia> using EaRydLattices

julia> lt = generate_sites(KagomeLattice(), 5, 5)
75-element Vector{Tuple{Float64, Float64}}:
 (0.0, 0.0)
 (0.25, 0.4330127018922193)
 (0.75, 0.4330127018922193)
 (1.0, 0.0)
 ⋮
 (6.0, 3.4641016151377544)
 (6.25, 3.8971143170299736)
 (6.75, 3.8971143170299736)

julia> grd = make_grid(lt[2:end-1])
MaskedGrid{Float64}([0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0, 2.25, 2.5  …  4.0, 
4.25, 4.5, 4.75, 5.0, 5.25, 5.5, 5.75, 6.0, 6.25], [0.0, 0.4330127018922193, 
0.8660254037844386, 1.299038105676658, 1.7320508075688772, 2.1650635094610964,
 2.598076211353316, 3.031088913245535, 3.4641016151377544, 3.8971143170299736], 
Bool[0 1 … 0 0; 0 0 … 0 0; … ; 0 0 … 1 0; 0 0 … 0 1])
```

![image](https://user-images.githubusercontent.com/6257240/144523738-58f6703d-cb55-451a-8be8-5f3586a1717b.png)
