### PR TITLE
adapt to new Yao api

### DIFF
--- a/lib/EaRydCUDA/Project.toml
+++ b/lib/EaRydCUDA/Project.toml
@@ -21,7 +21,7 @@ EaRydODE = "0.1"
 OrdinaryDiffEq = "5"
 Reexport = "1"
 EaRydCore = "0.1"
-Yao = "0.6"
+Yao = "0.7"
 julia = "1.6"
 
 [extras]

--- a/lib/EaRydCore/Project.toml
+++ b/lib/EaRydCore/Project.toml
@@ -46,7 +46,7 @@ StatsBase = "0.33"
 ThreadsX = "0.1"
 Transducers = "0.4"
 Unitful = "1"
-Yao = "0.6"
+Yao = "0.7"
 julia = "1.4"
 
 [extras]

--- a/lib/EaRydCore/src/mat.jl
+++ b/lib/EaRydCore/src/mat.jl
@@ -12,8 +12,8 @@ YaoBlocks.mat(x::AbstractBlock, s::Subspace) =
 YaoBlocks.mat(::Type{T}, d::TrivialGate{N}, s::Subspace) where {T,N} = IMatrix{length(s),T}()
 YaoBlocks.mat(::Type{T}, pb::PutBlock{N,C}, s::Subspace) where {T,N,C} =
     _cunmat(s.subspace_v, s.map, (), (), mat(T, pb.content), pb.locs)
-YaoBlocks.mat(::Type{T}, c::Subroutine{N,<:AbstractBlock}, s::Subspace) where {N,T} =
-    mat(T, PutBlock{N}(c.content, c.locs), s)
+YaoBlocks.mat(::Type{T}, c::Subroutine{D, <:AbstractBlock}, s::Subspace) where {D,T} =
+    mat(T, PutBlock(c.n, c.content, c.locs), s)
 YaoBlocks.mat(::Type{T}, x::Scale, s::Subspace) where {T} = YaoBlocks.factor(x) * mat(T, content(x), s)
 YaoBlocks.mat(::Type{T}, blk::Daggered, s::Subspace) where {T} = adjoint(mat(T, content(blk), s))
 YaoBlocks.mat(::Type{T}, c::ControlBlock{N,BT,C}, s::Subspace) where {T,N,BT,C} =

--- a/lib/EaRydCore/src/measure.jl
+++ b/lib/EaRydCore/src/measure.jl
@@ -33,3 +33,8 @@ end
 function Yao.measure(; nshots=1)
     reg -> Yao.measure(reg; nshots=nshots)
 end
+
+# TODO: remove this after https://github.com/QuantumBFS/Yao.jl/issues/338
+function Yao.expect(op::AbstractBlock, reg::RydbergReg)
+    return reg' * apply!(copy(reg), op)
+end

--- a/lib/EaRydCore/src/mis.jl
+++ b/lib/EaRydCore/src/mis.jl
@@ -83,7 +83,7 @@ struct ConfigAmplitude{Reg <: Yao.AbstractRegister}
     range::UnitRange{Int}
 end
 
-ConfigAmplitude(reg::Yao.AbstractRegister{1}) = ConfigAmplitude(reg, 1:size(reg.state, 1))
+ConfigAmplitude(reg::Yao.AbstractRegister{2}) = ConfigAmplitude(reg, 1:size(reg.state, 1))
 
 Base.eltype(it::ConfigAmplitude) = Tuple{Int, Yao.datatype(it.reg)}
 Base.length(it::ConfigAmplitude) = length(it.range)

--- a/lib/EaRydCore/src/register.jl
+++ b/lib/EaRydCore/src/register.jl
@@ -2,7 +2,7 @@ abstract type MemoryLayout end
 struct RealLayout <: MemoryLayout end
 struct ComplexLayout <: MemoryLayout end
 
-struct RydbergReg{Layout <: MemoryLayout, State, Space <: Subspace} <: Yao.AbstractRegister{1}
+struct RydbergReg{Layout <: MemoryLayout, State, Space <: Subspace} <: Yao.AbstractRegister{2}
     natoms::Int
     layout::Layout
     state::State
@@ -176,6 +176,6 @@ function set_zero_state!(r::Yao.ArrayReg)
     return r
 end
 
-function Base.:*(bra::Yao.YaoArrayRegister.AdjointRegister{1, <:RydbergReg}, ket::RydbergReg)
+function Base.:*(bra::Yao.YaoArrayRegister.AdjointRegister{2, <:RydbergReg}, ket::RydbergReg)
     return dot(statevec(parent(bra)), statevec(ket))
 end

--- a/lib/EaRydODE/Project.toml
+++ b/lib/EaRydODE/Project.toml
@@ -21,7 +21,7 @@ DiffEqCallbacks = "2"
 OrdinaryDiffEq = "5"
 Reexport = "1"
 EaRydCore = "0.1"
-Yao = "0.6"
+Yao = "0.7"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
I think the `reg' * reg` and `expect` should be generalized in upstream, they seem to be a regression due to https://github.com/QuantumBFS/Yao.jl/pull/336 and https://github.com/QuantumBFS/Yao.jl/pull/335