### PR TITLE
support dark theme

### DIFF
--- a/lib/BloqadeLattices/src/visualize.jl
+++ b/lib/BloqadeLattices/src/visualize.jl
@@ -1,4 +1,7 @@
 const DEFAULT_LINE_COLOR = Ref("#000000")
+const DEFAULT_TEXT_COLOR = Ref("#000000")
+const DEFAULT_NODE_COLOR = Ref("#FFFFFF")
+
 struct Rescaler{T}
     xmin::T
     xmax::T
@@ -98,7 +101,7 @@ Atoms within `blockade_radius` will be connected by bonds.
     pad::Float64 = 1.5 
 
     # axes
-    axes_text_color::String = DEFAULT_LINE_COLOR[]
+    axes_text_color::String = DEFAULT_TEXT_COLOR[]
     axes_text_fontsize::Float64 = 11.0
     axes_num_of_xticks = 5
     axes_num_of_yticks = 5
@@ -108,10 +111,10 @@ Atoms within `blockade_radius` will be connected by bonds.
 
     # node
     node_text_fontsize::Float64 = 5.0
-    node_text_color::String = DEFAULT_LINE_COLOR[]
+    node_text_color::String = DEFAULT_TEXT_COLOR[]
     node_stroke_color = DEFAULT_LINE_COLOR[]
     node_stroke_linewidth = 0.03
-    node_fill_color = "white"
+    node_fill_color = DEFAULT_NODE_COLOR[]
     # bond
     bond_color::String = DEFAULT_LINE_COLOR[]
     bond_linewidth::Float64 = 0.03
@@ -211,7 +214,7 @@ Base.@kwdef struct LatticeDisplayConfig
     pad::Float64 = 1.5
 
     # axes
-    axes_text_color::String = DEFAULT_LINE_COLOR[]
+    axes_text_color::String = DEFAULT_LINE_COLOR[]  # NOTE: follow the line color!
     axes_text_fontsize::Float64 = 11.0
     axes_num_of_xticks = 5
     axes_num_of_yticks = 5
@@ -221,10 +224,10 @@ Base.@kwdef struct LatticeDisplayConfig
 
     # node
     node_text_fontsize::Float64 = 5.0
-    node_text_color::String = DEFAULT_LINE_COLOR[]
+    node_text_color::String = DEFAULT_TEXT_COLOR[]
     node_stroke_color = DEFAULT_LINE_COLOR[]
     node_stroke_linewidth = 0.03
-    node_fill_color = "white"
+    node_fill_color = DEFAULT_NODE_COLOR[]
 
     # bond
     bond_color::String = DEFAULT_LINE_COLOR[]
@@ -441,4 +444,16 @@ for (mime, format) in [MIME"image/png" => PNG, MIME"text/html" => SVG]
             return nothing
         end
     end
+end
+
+function darktheme!()
+    DEFAULT_LINE_COLOR[] = "#FFFFFF"
+    DEFAULT_TEXT_COLOR[] = "#FFFFFF"
+    DEFAULT_NODE_COLOR[] = "#000000"
+end
+
+function lighttheme!()
+    DEFAULT_LINE_COLOR[] = "#000000"
+    DEFAULT_TEXT_COLOR[] = "#000000"
+    DEFAULT_NODE_COLOR[] = "#FFFFFF"
 end

--- a/lib/BloqadeLattices/test/runtests.jl
+++ b/lib/BloqadeLattices/test/runtests.jl
@@ -76,6 +76,7 @@ end
 end
 
 @testset "visualize" begin
+    BloqadeLattices.darktheme!()
     lt = generate_sites(KagomeLattice(), 5, 5, scale = 1.5)
     grd = make_grid(lt[2:end-1])
     unitvectors(lattice::AbstractLattice, scale::Real) = [((0.0, 0.0), v .* scale) for v in lattice_vectors(lattice)]
@@ -90,4 +91,8 @@ end
     @test show(IOBuffer(), MIME"text/html"(), lt) === nothing
     @test show(IOBuffer(), MIME"image/png"(), grd) === nothing
     @test show(IOBuffer(), MIME"image/png"(), lt) === nothing
+
+    BloqadeLattices.lighttheme!()
+    @test img_atoms(lt; colors = nothing) isa Compose.Context
+    @test show(IOBuffer(), MIME"text/html"(), lt) === nothing
 end


### PR DESCRIPTION
fix #358 , fix #92

Trigger this feature with:
```julia
julia> Bloqade.darktheme!()
```
![image](https://user-images.githubusercontent.com/6257240/171819681-0f6bcffa-af62-4911-a7f8-cb99ff81107f.png)
