### PR TITLE
Expanded Unit Tests and Code Coverage

### DIFF
--- a/lib/BloqadeExpr/src/space.jl
+++ b/lib/BloqadeExpr/src/space.jl
@@ -20,36 +20,36 @@ A constant for the [`FullSpace`](@ref).
 const fullspace = FullSpace()
 
 """
-    Subspace{S <: AbstractVector{Int}} <: AbstractSpace
+    Subspace{S <: AbstractVector} <: AbstractSpace
 
 A `Dict`-like object stores the mapping between subspace and full space.
 """
-struct Subspace{S<:AbstractVector{Int}} <: AbstractSpace
+struct Subspace{T, S<:AbstractVector{T}} <: AbstractSpace
     nqubits::Int
-    map::Dict{Int,Int} # fullspace_index => subspace_index
+    map::Dict{T,T} # fullspace_index => subspace_index
     subspace_v::S
 
-    function Subspace(nqubits::Int, map::Dict{Int,Int}, subspace_v)
-        maximum(subspace_v) ≤ 1 << nqubits || throw(ArgumentError("subspace index is too large"))
-        return new{typeof(subspace_v)}(nqubits, map, subspace_v)
+    function Subspace(nqubits::Int, map::Dict{T,T}, subspace_v) where T<:Integer
+        maximum(subspace_v) ≤ one(T) << nqubits || throw(ArgumentError("subspace index is too large"))
+        return new{T,typeof(subspace_v)}(nqubits, map, subspace_v)
     end
 end
 
 """
-    Subspace(nqubits::Int, subspace_v::AbstractVector{Int})
+    Subspace(nqubits::Int, subspace_v::AbstractVector)
 
 Create a Subspace from given list of subspace indices in the corresponding full space.
 """
-function Subspace(nqubits::Int, subspace_v::AbstractVector{Int})
+function Subspace(nqubits::Int, subspace_v::AbstractVector{T}) where T<:Integer
     subspace_v = sort(subspace_v)
-    map = Dict{Int,Int}()
+    map = Dict{T,T}()
     for (subspace_index, fullspace_index) in enumerate(subspace_v)
         map[fullspace_index] = subspace_index
     end
     return Subspace(nqubits, map, subspace_v)
 end
 
-function Base.show(io::IO, ::MIME"text/plain", s::Subspace{S}) where {S}
+function Base.show(io::IO, ::MIME"text/plain", s::Subspace)
     print(io, s.nqubits, "-qubits ", length(s.subspace_v), "-elements ")
     summary(io, s)
     println(io, ":")
@@ -96,7 +96,7 @@ function Base.show(io::IO, ::MIME"text/plain", s::Subspace{S}) where {S}
     end
 end
 
-Base.getindex(s::Subspace, key::Int) = s.map[key]
+Base.getindex(s::Subspace, key::Integer) = s.map[key]
 Base.getindex(s::Subspace, key::BitStr) = s.map[buffer(key)]
 Base.keys(s::Subspace) = keys(s.map)
 Base.values(s::Subspace) = values(s.map)

--- a/lib/BloqadeExpr/test/space.jl
+++ b/lib/BloqadeExpr/test/space.jl
@@ -4,12 +4,61 @@ using BloqadeExpr
 @testset "subspace" begin
     @test_throws ArgumentError space = Subspace(8, [1, 3, 5, 300])
 
+    # 1, 3, 5, 10 are full space indexes
+    # map[fullspace_index] = subspace index
     space = Subspace(8, [1, 3, 5, 10])
     @test space.map[3] == 2
     @test space.map[10] == 4
 
+    for pair in space
+        @test pair.first in keys(space)
+        @test pair.second in values(space)
+    end
+
+    @test space[10] == 4
+
+    @test space[bit"1010"] == 4
+
+    @test keys(space) == Set([1, 3, 5, 10])
+
+    @test sort(collect(values(space))) == [1, 2, 3, 4]
+
+    @test haskey(space, 1)
+    
+    copied_space = copy(space)
+    @test copied_space.nqubits == space.nqubits
+    @test copied_space.map == space.map
+    @test copied_space.subspace_v == space.subspace_v
+
+    @test vec(space) == [1, 3, 5, 10]
+
     state = rand(15)
     @test state[space] == state[[2, 4, 6, 11]]
-
+    
+    # non-compact print
     show(stdout, MIME"text/plain"(), space)
+
+    print("\n\n")
+
+    # compact print
+    space = Subspace(6, [i for i in 1:40])
+    show(IOContext(stdout, :limit => true), MIME"text/plain"(), space)
+
+    # all contents equal
+    space1 = Subspace(6, [i for i in 1:40])
+    space2 = Subspace(6, [i for i in 1:40])
+    @test space1 == space2
+
+    # nqubits mismatch
+    space2 = Subspace(7, [i for i in 1:40])
+    @test !(space1 == space2)
+
+    # subspace values length mismatch
+    space2 = Subspace(6, [i for i in 1:20])
+    @test !(space1 == space2)
+
+    # map mismatch
+    space2 = Subspace(6, [i for i in 5:44])
+    @test !(space1 == space2)
+
 end

--- a/lib/BloqadeExpr/test/types.jl
+++ b/lib/BloqadeExpr/test/types.jl
@@ -1,6 +1,7 @@
 using Test
-using BloqadeExpr, YaoBlocks, BitBasis
+using BloqadeExpr, YaoBlocks, YaoAPI, BitBasis
 using SparseArrays
+using LinearAlgebra
 
 @testset "getindex" begin
     pb = rydberg_h([(5*randn(), 5*randn()) for i=1:5]; Ω=0.3, Δ=0.5)
@@ -19,4 +20,55 @@ using SparseArrays
         allpass &= vec(pb[EntryTable([j], [1.0+0im]),:]) ≈ mpb[Int(j)+1,:]
     end
     @test allpass
+end
+
+@testset "isreal" begin
+
+    @test isreal(SumOfN(nsites=2))
+
+    @test isreal(SumOfZ(nsites=2))
+
+    scale = 2 * SumOfX(nsites=3)
+    @test isreal(scale)
+    scale = im * SumOfX(nsites=3)
+    @test !isreal(scale)
+end
+
+@testset "Hamiltonian Term Default Values" begin
+    pauli_zs_term = SumOfZ(2)
+    @test pauli_zs_term.Δ == 1
+    
+    number_ops_term = SumOfN(2)
+    @test number_ops_term.Δ == 1
+
+    pauli_xs_term = SumOfX(2)
+    @test pauli_xs_term.Ω == 1
+end
+
+@testset "Qudit Numbers" begin
+    @test YaoAPI.nqudits(PdPhase(1.0)) == 1
+    @test YaoAPI.nqudits(PuPhase(1.0)) == 1
+    @test YaoAPI.nqudits(SumOfZ(10)) == 10
+end
+
+@testset "SumOfZ Equality Operator" begin
+    @test SumOfZ(10, 1.0) == SumOfZ(10, 1.0)
+    @test !(SumOfZ(1, 1.0) == SumOfZ(2, 1.0))
+    @test !(SumOfZ(5, 0.5) == SumOfZ(5, 0.3))
+end
+
+@testset "Hamiltonian Size" begin
+    hamiltonian = BloqadeExpr.Hamiltonian(Float64, SumOfX(6, sin) + SumOfZ(6, cos))
+    @test size(hamiltonian) == (64, 64)
+    @test size(hamiltonian, 2) == 64
+    
+    step_hamiltonian = hamiltonian(0.1)
+    @test size(step_hamiltonian) == (64, 64)
+    @test size(step_hamiltonian, 2) == 64
+end
+
+@testset "Step Hamiltonian Norm" begin 
+    hamiltonian = BloqadeExpr.Hamiltonian(Float64, SumOfZ(1, sin))
+    step_hamiltonian = hamiltonian(π/2)
+    @test LinearAlgebra.opnorm(step_hamiltonian) == 1.0
 end

--- a/lib/BloqadeLattices/src/neighbors.jl
+++ b/lib/BloqadeLattices/src/neighbors.jl
@@ -60,12 +60,7 @@ Returns a [`DistanceGroup`](@ref) instance.
 ```jldoctest; setup=:(using BloqadeLattices)
 julia> atoms = generate_sites(HoneycombLattice(), 5, 5);
 
-julia> tree = make_kdtree(atoms)
-NearestNeighbors.KDTree{StaticArrays.SVector{2, Float64}, Distances.Euclidean, Float64}
-  Number of points: 50
-  Dimensions: 2
-  Metric: Distances.Euclidean(0.0)
-  Reordered: true
+julia> tree = make_kdtree(atoms);
 
 julia> gn = grouped_nearest(tree, 23, 20)
 DistanceGroup([23, 14, 22, 24, 15, 13, 21, 25, 33, 31, 12, 16, 32, 4, 6, 34, 26, 17, 5, 41], [1, 2, 5, 11, 14, 18, 21])

--- a/lib/BloqadeLattices/test/runtests.jl
+++ b/lib/BloqadeLattices/test/runtests.jl
@@ -20,6 +20,7 @@ end
         KagomeLattice(),
         GeneralLattice(((1.0, 0.0), (0.0, 1.0)), [(0.0, 0.0)]),
     ]
+        @test BloqadeLattices.dimension(LT) == 2
         @test generate_sites(LT, 5, 5) |> length == length(lattice_sites(LT)) * 25
     end
     lt1 = generate_sites(ChainLattice(), 5)
@@ -40,6 +41,13 @@ end
     l5 = random_dropout(l3, 0.5)
     @test length(l5) == 7
     @test_throws ArgumentError random_dropout(l3, -0.5)
+
+    # Rectangular Lattice Defaults
+    rectangular_lattice = RectangularLattice(1.0)
+    @test lattice_sites(rectangular_lattice) == ((0.0, 0.0),)
+    @test lattice_vectors(rectangular_lattice)[2][2] == rectangular_lattice.aspect_ratio
+
+    # Lattice Dimensions
 
     # rescale axes
     sites = AtomList([(0.2, 0.3), (0.4, 0.8)])

--- a/lib/BloqadeMIS/src/subspace.jl
+++ b/lib/BloqadeMIS/src/subspace.jl
@@ -1,9 +1,9 @@
 """
-    independent_set_subspace(graph)
+    independent_set_subspace([T, ]graph)
 
 Create a subspace from given graph's maximal independent set.
 """
-function independent_set_subspace(graph::SimpleGraph)
+function independent_set_subspace(::Type{T}, graph::SimpleGraph) where T
     if isempty(edges(graph))
         @warn "graph has empty edges, creating a subspace contains the entire fullspace, consider using a full space register."
     end
@@ -11,11 +11,17 @@ function independent_set_subspace(graph::SimpleGraph)
     cg = complement(graph)
     mis = maximal_cliques(cg)
     n = nv(graph)
-    return create_subspace_from_mis(n, mis)
+    return create_subspace_from_mis(T, n, mis)
+end
+
+function independent_set_subspace(graph::SimpleGraph) where T
+    n = nv(graph)
+    @assert n <= 128 "number of vertices in a graph is too large! $(n) > 128"
+    independent_set_subspace(n > 64 ? Int128 : Int64, graph)
 end
 
 """
-    create_subspace_from_mis(n::Int, mis::AbstractVector)
+    create_subspace_from_mis(T, n::Int, mis::AbstractVector)
 
 Create `Subspace` from given list of maximal cliques/maximal independent set.
 
@@ -24,20 +30,22 @@ Create `Subspace` from given list of maximal cliques/maximal independent set.
 - `n`: number of vertices of the graph.
 - `mis`: the list of maximal independent set.
 """
-function create_subspace_from_mis(n::Int, mis::AbstractVector)
+function create_subspace_from_mis(::Type{T}, n::Int, mis::AbstractVector) where T
     iterators = ThreadsX.map(mis) do each
         fixed_points = setdiff(1:n, each)
         locs = sort!(fixed_points)
         # copied from bsubspace to use runtime length
-        masks, shift_len = group_shift(locs)
-        len = 1 << (n - length(locs))
+        masks, shift_len = group_shift(T, locs)
+        len = one(T) << (n - length(locs))
+        a = BitSubspace(n, len, length(masks), masks, shift_len)
+        b = BitSubspace(n, len, length(masks), masks, shift_len)
         return BitSubspace(n, len, length(masks), masks, shift_len)
     end
 
     # NOTE: ThreadsX doesn't support auto init when using union as op
     # need the following PR merged
     # https://github.com/JuliaFolds/InitialValues.jl/pull/60
-    subspace_v = ThreadsX.reduce(union, iterators; init = OnInit(Vector{Int}))
+    subspace_v = ThreadsX.reduce(union, iterators; init = OnInit(Vector{T}))
     return Subspace(n, subspace_v)
 end
 

--- a/lib/BloqadeMIS/test/loss.jl
+++ b/lib/BloqadeMIS/test/loss.jl
@@ -87,3 +87,9 @@ end
     expected_exact = r |> gibbs_loss(0.5)
     @test isapprox(expected_exact, expected_sampling; rtol = 1e-1)
 end
+
+@testset "128 bit" begin
+    s = independent_set_subspace(Int128, Graphs.complete_graph(66))
+    @test length(s) == 67
+    @test s.subspace_v == Int128[one(Int128)<<(i-1) for i=0:66]
+end

--- a/lib/BloqadeMIS/test/loss.jl
+++ b/lib/BloqadeMIS/test/loss.jl
@@ -71,6 +71,17 @@ end
     @test l1 ≈ l2
 end
 
+
+@testset "indepent set subspace with no edges" begin
+    no_edges_warning = "graph has empty edges, creating a subspace contains the entire fullspace, consider using a full space register."
+    no_edges_graph = Graph(5)
+
+    @test_logs (:warn, no_edges_warning) independent_set_subspace(no_edges_graph)
+
+    atoms = generate_sites(RectangularLattice(1.0), 3, 3; scale = 4.5)
+    @test_logs (:warn, no_edges_warning) blockade_subspace(atoms)
+end
+
 @testset "exact/sample based loss function" begin
     r = rand_state(5)
     samples = measure(r; nshots = 10000)

--- a/lib/BloqadeMIS/test/runtests.jl
+++ b/lib/BloqadeMIS/test/runtests.jl
@@ -1,6 +1,14 @@
 using Test
 using BloqadeMIS
 
+@testset "unit_disk_graph" begin
+    include("unit_disk_graph.jl")
+end
+
+@testset "utils" begin
+    include("utils.jl")
+end
+
 @testset "loss" begin
     include("loss.jl")
 end

--- a/lib/BloqadeSchema/test/execute.jl
+++ b/lib/BloqadeSchema/test/execute.jl
@@ -273,3 +273,20 @@ end
     #     """{"shot_status_code":200,"pre_sequence":[1,1,1,1,1,1],"post_sequence":[0,0,0,0,0,0]},""",
     #     """{"shot_status_code":200,"pre_sequence":[1,1,1,1,1,1],"post_sequence":[0,0,0,0,0,0]}]}""")
 end
+
+@testset "to_task_output" begin
+    bitstrings = [bit"010", bit"110", bit"111"]
+    bitstrings_as_vectors = [Vector{Int32}([0,1,0]),
+                             Vector{Int32}([0,1,1]),
+                             Vector{Int32}([1,1,1])]
+    
+    task_output = BloqadeSchema.to_task_output(bitstrings)
+
+    @test task_output.task_status_code == 200
+
+    for (shot, bitstring_as_vector) in collect(zip(task_output.shot_outputs, bitstrings_as_vectors))
+        @test shot.shot_status_code == 200
+        @test shot.pre_sequence == Vector{Int32}([1,1,1])
+        @test shot.post_sequence == bitstring_as_vector
+    end
+end


### PR DESCRIPTION
Added a number of new unit tests that address the following and expand missing code coverage:

* subspaces should be compatible with defined interfaces
* Hamiltonian-related functions (such as finding the norm for step hamiltonians)
* `RectangularLattice`'s default values (ex: aspect ratio)
* feeding a graph with no edges to `BloqadeMIS.independent_set_subspace` should issue a warning that the full space will be used. This behavior should remain consistent even when called by `blockade_subspace`
* `BloqadeSchema.to_task_output` generates the expected `TaskOutput` with the proper status codes and shots from a vector of bitstrings