### PR TITLE
[WIP] add get_average_rydberg_densities to src/observables.jl

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,4 +39,4 @@ pkg> add Bloqade#master
 
 ## License
 
-Apache License 2.0
+Apache License 2.0 

--- a/README.md
+++ b/README.md
@@ -39,4 +39,4 @@ pkg> add Bloqade#master
 
 ## License
 
-Apache License 2.0 
+Apache License 2.0

--- a/src/Bloqade.jl
+++ b/src/Bloqade.jl
@@ -39,7 +39,7 @@ using Reexport
     grouped_nearest,
     collect_atoms
 
-export rydberg_density, rydberg_corr, bitstring_hist, bitstring_hist!
+export rydberg_density, rydberg_corr, bitstring_hist, bitstring_hist!, get_average_rydberg_densities
 
 using PythonCall
 const plt = PythonCall.pynew()

--- a/src/observables.jl
+++ b/src/observables.jl
@@ -40,10 +40,9 @@ end
 
 
 """
-    get_average_rydberg_densities(atoms, Δ, Ω, ϕ; dt=1e-3)
+    get_average_rydberg_densities(atoms, reg; [C=2π * 862690 * MHz*µm^6], Ω[, ϕ, Δ], [dt=1e-3 * μs])
 
 Return average Rydberg densities throughout an evolution
-
 
 # Arguments
 

--- a/src/observables.jl
+++ b/src/observables.jl
@@ -74,7 +74,7 @@ function get_average_rydberg_densities(atoms, reg::AbstractRegister; C::Real = 2
     duration = allwaveforms[1].duration
     for i = 2 : length(allwaveforms)
         if allwaveforms[i].duration != duration
-            error("The durations of waveforms are not consistent.")
+            error("The durations of waveforms are not consistent.") 
         end
     end
 

--- a/src/observables.jl
+++ b/src/observables.jl
@@ -62,7 +62,7 @@ function get_average_rydberg_densities(atoms, reg; C = 2π * 862690, Ω = nothin
 
     # Get the duration for the evolution
     if isnothing(Ω) && isnothing(ϕ) && isnothing(Δ)
-        error("At least one of Ω, ϕ or Δ needs to be specified for determining the duration of the evolution.")
+        error("At least one of Ω, ϕ or Δ is needed for determining the duration of the evolution.")
     end
 
     allwaveforms = [Ω, ϕ, Δ]
@@ -71,7 +71,7 @@ function get_average_rydberg_densities(atoms, reg; C = 2π * 862690, Ω = nothin
     duration = allwaveforms[1].duration
     for i = 2 : length(allwaveforms)
         if allwaveforms[i].duration != duration
-            error("The durations of waveforms are not consisteng.")
+            error("The durations of waveforms are not consistent.")
         end
     end
 

--- a/src/observables.jl
+++ b/src/observables.jl
@@ -37,3 +37,54 @@ rydberg_corr(reg) = rydberg_corr(Op.n, reg)
 function rydberg_corr(op, reg)
     return [expect(chain(nqubits(reg), put(i => op), put(j => op)), reg) for i in 1:nqubits(reg), j in 1:nqubits(reg)]
 end
+
+
+"""
+    get_average_rydberg_densities(atoms, Δ, Ω, ϕ; dt=1e-3)
+
+Return average Rydberg densities throughout an evolution
+
+
+# Arguments
+
+- `atoms`: a collection of atom positions.
+- `reg`: required, the register object.
+
+# Keyword Arguments
+
+- `C`: optional, default unit is `MHz*µm^6`, interation parameter,
+    see also [`RydInteract`](@ref).
+- `Ω`: optional, default unit is `MHz`, Rabi frequencies, divided by 2, see also [`SumOfX`](@ref).
+- `ϕ`: optional, does not have unit, the phase, see [`SumOfXPhase`](@ref).
+- `Δ`: optional, default unit is `MHz`, detuning parameter, see [`SumOfN`](@ref).
+- `dt`: optional, default unit is `μs`, time step for the evolution
+"""
+function get_average_rydberg_densities(atoms, reg; C = 2π * 862690, Ω = nothing, ϕ = nothing, Δ = nothing, dt=1e-3)
+
+    # Get the duration for the evolution
+    if isnothing(Ω) && isnothing(ϕ) && isnothing(Δ)
+        error("At least one of Ω, ϕ or Δ needs to be specified for determining the duration of the evolution.")
+    end
+
+    allwaveforms = [Ω, ϕ, Δ]
+    allwaveforms = allwaveforms[allwaveforms.!=nothing]
+    allwaveforms = reduce(vcat, allwaveforms)
+    duration = allwaveforms[1].duration
+    for i = 2 : length(allwaveforms)
+        if allwaveforms[i].duration != duration
+            error("The durations of waveforms are not consisteng.")
+        end
+    end
+
+    # Start the evolution 
+    h = rydberg_h(atoms, C=C, Δ=Δ, Ω=Ω, ϕ=ϕ)
+    prob = SchrodingerProblem(reg, duration, h, progress=true);
+    integrator = init(prob, Vern8());
+    densities = []
+    for _ in TimeChoiceIterator(integrator, 0.0:dt:duration)
+        normalize!(reg) 
+        push!(densities, rydberg_density(reg)) 
+    end
+
+    return densities    
+end

--- a/src/observables.jl
+++ b/src/observables.jl
@@ -58,7 +58,7 @@ Return average Rydberg densities throughout an evolution
 - `Δ`: optional, default unit is `MHz`, detuning parameter, see [`SumOfN`](@ref).
 - `dt`: optional, default unit is `μs`, time step for the evolution
 """
-function get_average_rydberg_densities(atoms, reg; C = 2π * 862690, Ω = nothing, ϕ = nothing, Δ = nothing, dt=1e-3)
+function get_average_rydberg_densities(atoms, reg::AbstractRegister; C::Real = 2π * 862690, Ω = nothing, ϕ = nothing, Δ = nothing, dt::Real=1e-3)
 
     # Get the duration for the evolution
     if isnothing(Ω) && isnothing(ϕ) && isnothing(Δ)

--- a/src/observables.jl
+++ b/src/observables.jl
@@ -60,7 +60,6 @@ Return average Rydberg densities throughout an evolution.
 - `solver`: optional, default solver is `Vern8()`, the solver for the SchrodingerProblem, see [`SchrodingerProblem`](@ref).
 """
 function get_average_rydberg_densities(atoms, reg::AbstractRegister; C::Real = 2π * 862690, Ω = nothing, ϕ = nothing, Δ = nothing, dt::Real=1e-3, solver = Vern8())
-
     if isnothing(Ω) && isnothing(ϕ) && isnothing(Δ)
         error("At least one of Ω, ϕ or Δ is needed for determining the duration of the evolution.")
     end
@@ -69,6 +68,7 @@ function get_average_rydberg_densities(atoms, reg::AbstractRegister; C::Real = 2
     allwaveforms = [Ω, ϕ, Δ] 
     allwaveforms = allwaveforms[allwaveforms.!=nothing] # Get rid of the non-specified (Ω, ϕ, Δ)
     allwaveforms = reduce(vcat, allwaveforms) # We flatten the list such that `allwaveforms` is a list of nonzero waveforms 
+    allwaveforms = isa(allwaveforms, Waveform) ? [allwaveforms] : allwaveforms
 
     # The duration of the evolution is well-defined if and only if the durations of all waveforms are the same
     duration = allwaveforms[1].duration
@@ -88,5 +88,5 @@ function get_average_rydberg_densities(atoms, reg::AbstractRegister; C::Real = 2
         push!(densities, rydberg_density(reg)) 
     end
 
-    return densities    
+    return densities
 end

--- a/src/observables.jl
+++ b/src/observables.jl
@@ -42,7 +42,7 @@ end
 """
     get_average_rydberg_densities(atoms, reg; [C=2π * 862690 * MHz*µm^6], Ω[, ϕ, Δ], [dt=1e-3 * μs])
 
-Return average Rydberg densities throughout an evolution
+Return average Rydberg densities throughout an evolution.
 
 # Arguments
 
@@ -56,7 +56,8 @@ Return average Rydberg densities throughout an evolution
 - `Ω`: optional, default unit is `MHz`, Rabi frequencies, divided by 2, see also [`SumOfX`](@ref).
 - `ϕ`: optional, does not have unit, the phase, see [`SumOfXPhase`](@ref).
 - `Δ`: optional, default unit is `MHz`, detuning parameter, see [`SumOfN`](@ref).
-- `dt`: optional, default unit is `μs`, time step for the evolution
+- `dt`: optional, default unit is `μs`, time step for the evolution.
+- `solver`: optional, default solver is `Vern8()`, the solver for the SchrodingerProblem, see [`SchrodingerProblem`](@ref).
 """
 function get_average_rydberg_densities(atoms, reg::AbstractRegister; C::Real = 2π * 862690, Ω = nothing, ϕ = nothing, Δ = nothing, dt::Real=1e-3, solver = Vern8())
 

--- a/test/observables.jl
+++ b/test/observables.jl
@@ -7,3 +7,11 @@ reg = rand_state(10)
 
 @test rydberg_corr(reg) ≈
       [expect(chain(nqubits(reg), put(i => Op.n), put(j => Op.n)), reg) for i in 1:nqubits(reg), j in 1:nqubits(reg)]
+
+
+# Test 1 for get_average_rydberg_densities: π-pulse for 1-atom
+@test [[0.0], [1.0]] ≈ get_average_rydberg_densities(
+      generate_sites(ChainLattice(), 1), 
+      zero_state(1); 
+      Ω = piecewise_linear(clocks = [0.0, 0.1], values = [π/(0.1), π/(0.1)]), 
+      dt=0.1)


### PR DESCRIPTION
Adding a wrapper function `get_average_rydberg_densities` to src/observables.jl. The function returns the average Rydberg density throughout the evolution, determined by the given waveforms. 

Tests: Not done yet, but the function was tried on the lattice gauge theory example, which produces the correct result. 