### PR TITLE
broadcasting conversion of position units.

### DIFF
--- a/lib/BloqadeSchema/src/parse.jl
+++ b/lib/BloqadeSchema/src/parse.jl
@@ -379,7 +379,7 @@ function parse_analog_rydberg_params(h::BloqadeExpr.RydbergHamiltonian,params::S
     # and each case requires a lot of code.
 
     atoms = map(atoms) do pos 
-                return (convert_units(pos[1],μm,m),convert_units(pos[2],μm,m))
+                return convert_units.(pos,μm,m)
             end
     ϕ,Ω,Δ,δ,Δ_local = parse_analog_rydberg_fields(ϕ,Ω,Δ,params)
 

--- a/lib/BloqadeSchema/test/parse.jl
+++ b/lib/BloqadeSchema/test/parse.jl
@@ -13,7 +13,17 @@ using BloqadeSchema:
 using Unitful: μs, s, MHz, rad 
     
 
+@testset "convert_units" begin
+    T = 1 # seconds
+    T_list = [i for i in 1:10]
+    pair = (1,2)
+    pair_list = [(i,j) for i in 1:5 for j in 1:5]
+    @test 1e6 ≈ convert_units(T,s,μs)
+    @test (1e6 .* T_list) ≈ convert_units(T_list,s,μs)
+    @test all((1e6 .* pair ).≈ convert_units.(pair,s,μs))
+    # @test all([1e6.*p for p in pair_list] .≈ convert_units.(pair_list,s,μs))
 
+end
 
 @testset "parse_dynamic_rydberg_Ω" begin
 


### PR DESCRIPTION
as stated, in cases where positions do not have a y-coordinate the current code doesn't work so broadcasting fixes this. 