### PR TITLE
Rounding Schema values

### DIFF
--- a/lib/BloqadeSchema/src/execute.jl
+++ b/lib/BloqadeSchema/src/execute.jl
@@ -55,7 +55,7 @@ function from_schema(t::TaskSpecification)
     atoms = (site for (i,site) in enumerate(t.lattice.sites) if t.lattice.filling[i] == 1)
 
     atoms = map(atoms) do pos 
-        return (convert_units(pos[1],m,μm),convert_units(pos[2],m,μm))
+        return convert_units.(pos,m,μm)
     end
 
     rabi_freq_amp = t.effective_hamiltonian.rydberg.rabi_frequency_amplitude.global_value
@@ -125,29 +125,70 @@ function to_dict(h::BloqadeExpr.RydbergHamiltonian, params::SchemaConversionPara
     return Configurations.to_dict(to_schema(h, params))
 end
 
+
+
 function to_schema(h::BloqadeExpr.RydbergHamiltonian, params::SchemaConversionParams)
     atoms,ϕ,Ω,Δ,δ,Δi = parse_analog_rydberg_params(h,params)
+    
 
-    ϕ = piecewise_linear(;
-        clocks=convert_units(ϕ.f.clocks,μs,s),
-        values=convert_units(ϕ.f.values,rad,rad)
+    ϕ_clocks = convert_units(ϕ.f.clocks,μs,s) 
+    ϕ_values = convert_units(ϕ.f.values,rad,rad)
+    Ω_clocks = convert_units(Ω.f.clocks,μs,s)
+    Ω_values = convert_units(Ω.f.values,rad*MHz,rad/s)
+    Δ_clocks = convert_units(Δ.f.clocks,μs,s)
+    Δ_values = convert_units(Δ.f.values,rad*MHz,rad/s)
+
+    if params.discretize
+        atoms = map(atoms) do pos
+            return set_resolution.(pos,params.atom_position_resolution)
+        end
+        
+        ϕ_clocks = set_resolution.(ϕ_clocks, params.rabi_time_resolution) 
+        ϕ_values = set_resolution.(ϕ_values, params.rabi_frequency_phase_resolution)
+
+        Ω_clocks = set_resolution.(Ω_clocks, params.rabi_time_resolution)
+        Ω_values = set_resolution.(Ω_values, params.rabi_frequency_amplitude_resolution)
+
+        Δ_clocks = set_resolution.(Δ_clocks, params.rabi_time_resolution) 
+        Δ_values = set_resolution.(Δ_values, params.rabi_detuning_resolution)
+
+    end
+
+
+
+    ϕ =(
+        clocks=ϕ_clocks,
+        values=ϕ_values
     )
 
-    Ω = piecewise_linear(;
-        clocks=convert_units(Ω.f.clocks,μs,s),
-        values=convert_units(Ω.f.values,rad*MHz,rad/s)
+
+    Ω = (
+        clocks=Ω_clocks,
+        values=Ω_values
     )
 
-    Δ = piecewise_linear(;
-        clocks=convert_units(Δ.f.clocks,μs,s),
-        values=convert_units(Δ.f.values,rad*MHz,rad/s)
+
+    Δ = (
+        clocks=Δ_clocks,
+        values=Δ_values
     )
 
     if !isnothing(δ)
-        δ = piecewise_linear(;
-            clocks=convert_units(δ.f.clocks,μs,s),
-            values=convert_units(δ.f.values,rad*MHz,rad/s)
+        δ_clocks = convert_units(δ.f.clocks,μs,s)
+        δ_values = convert_units(δ.f.values,rad*MHz,rad/s)
+        
+        if params.discretize
+            δ_clocks = set_resolution.(δ_clocks, params.rabi_time_resolution)
+            δ_values = set_resolution.(δ_values, params.rabi_detuning_local_resolution)
+            Δi = set_resolution.(Δi, params.rabi_detuning_local_resolution)
+        end
+        
+        δ = (
+            clocks=δ_clocks,
+            values=δ_values
         )
+    else
+
     end
 
     return TaskSpecification(;
@@ -169,46 +210,46 @@ end
 
 
 function to_hamiltonian(
-    Ω::Waveform{BloqadeWaveforms.PiecewiseLinear{T,Interp},T},
-    ϕ::Waveform{BloqadeWaveforms.PiecewiseLinear{T,Interp},T},
-    Δ::Waveform{BloqadeWaveforms.PiecewiseLinear{T,Interp},T},
-    δ::Maybe{Waveform{BloqadeWaveforms.PiecewiseLinear{T,Interp},T}},
-    Δ_i::Vector{<:Real}) where {T<:Real,Interp}
+    Ω::NamedTuple,
+    ϕ::NamedTuple,
+    Δ::NamedTuple,
+    δ::Maybe{NamedTuple},
+    Δ_i::Vector{<:Real}) 
 
     return EffectiveHamiltonian(;
         rydberg = RydbergHamiltonian(;
             rabi_frequency_amplitude = RydbergRabiFrequencyAmplitude(;
-                global_value = RydbergRabiFrequencyAmplitudeGlobal(; times = Ω.f.clocks, values = Ω.f.values),
+                global_value = RydbergRabiFrequencyAmplitudeGlobal(; times = Ω.clocks, values = Ω.values),
             ),
             rabi_frequency_phase = RydbergRabiFrequencyPhase(;
-                global_value = RydbergRabiFrequencyPhaseGlobal(; times = ϕ.f.clocks, values = ϕ.f.values),
+                global_value = RydbergRabiFrequencyPhaseGlobal(; times = ϕ.clocks, values = ϕ.values),
             ),
             detuning = RydbergDetuning(;
-                global_value = RydbergDetuningGlobal(; times = Δ.f.clocks, values = Δ.f.values),
-                local_value = RydbergDetuningLocal(; times = δ.f.clocks, values = δ.f.values, lattice_site_coefficients=Δ_i)
+                global_value = RydbergDetuningGlobal(; times = Δ.clocks, values = Δ.values),
+                local_value = RydbergDetuningLocal(; times = δ.clocks, values = δ.values, lattice_site_coefficients=Δ_i)
             ),
         ),
     )
 end
 
 function to_hamiltonian(
-    Ω::Waveform{BloqadeWaveforms.PiecewiseLinear{T,Interp},T},
-    ϕ::Waveform{BloqadeWaveforms.PiecewiseLinear{T,Interp},T},
-    Δ::Waveform{BloqadeWaveforms.PiecewiseLinear{T,Interp},T},
-    δ::Maybe{Waveform{BloqadeWaveforms.PiecewiseLinear{T,Interp},T}},
+    Ω::NamedTuple,
+    ϕ::NamedTuple,
+    Δ::NamedTuple,
+    δ::Maybe{NamedTuple},
     Δ_i::Real) where {T<:Real,Interp}
 
     return EffectiveHamiltonian(;
         rydberg = RydbergHamiltonian(;
             rabi_frequency_amplitude = RydbergRabiFrequencyAmplitude(;
-                global_value = RydbergRabiFrequencyAmplitudeGlobal(; times = Ω.f.clocks, values = Ω.f.values),
+                global_value = RydbergRabiFrequencyAmplitudeGlobal(; times = Ω.clocks, values = Ω.values),
             ),
             rabi_frequency_phase = RydbergRabiFrequencyPhase(;
-                global_value = RydbergRabiFrequencyPhaseGlobal(; times = ϕ.f.clocks, values = ϕ.f.values),
+                global_value = RydbergRabiFrequencyPhaseGlobal(; times = ϕ.clocks, values = ϕ.values),
             ),
             detuning = RydbergDetuning(;
-                global_value = RydbergDetuningGlobal(; times = Δ.f.clocks, values = Δ.f.values),
-                # local_value = RydbergDetuningLocal(; times = δ.f.clocks, values = δ.f.values, lattice_site_coefficients=Δ_i)
+                global_value = RydbergDetuningGlobal(; times = Δ.clocks, values = Δ.values),
+                # local_value = RydbergDetuningLocal(; times = δ.clocks, values = δ.values, lattice_site_coefficients=Δ_i)
             ),
         ),
     )

--- a/lib/BloqadeSchema/src/execute.jl
+++ b/lib/BloqadeSchema/src/execute.jl
@@ -213,7 +213,7 @@ function to_hamiltonian(
     Ω::NamedTuple,
     ϕ::NamedTuple,
     Δ::NamedTuple,
-    δ::Maybe{NamedTuple},
+    δ::NamedTuple,
     Δ_i::Vector{<:Real}) 
 
     return EffectiveHamiltonian(;
@@ -236,8 +236,8 @@ function to_hamiltonian(
     Ω::NamedTuple,
     ϕ::NamedTuple,
     Δ::NamedTuple,
-    δ::Maybe{NamedTuple},
-    Δ_i::Real) where {T<:Real,Interp}
+    δ::Nothing,
+    Δ_i::Real)
 
     return EffectiveHamiltonian(;
         rydberg = RydbergHamiltonian(;

--- a/lib/BloqadeSchema/src/parse.jl
+++ b/lib/BloqadeSchema/src/parse.jl
@@ -73,7 +73,7 @@ end
 function convert_units(x::AbstractArray{S},from,to;res=nothing) where {S<:Real}
     y = similar(x)
     @inbounds for i in eachindex(x)
-        y[i] = convert_units(x[i],from,to;res=res)
+        y[i] = convert_units(x[i],from,to)
     end
     return y
 end
@@ -112,7 +112,7 @@ end
 
 
 function parse_static_rydberg_Ω(Ω::ConstantParam,duration::Real,params)
-    if isnothing(Ω) || Ω == 0
+    if isnothing(Ω) || iszero(Ω)
         return piecewise_linear(;clocks=Float64[0.0,duration],values=Float64[0.0,0.0])
     elseif Ω isa Real
         # constraints = get_constraints(params)
@@ -130,7 +130,7 @@ function parse_static_rydberg_Ω(Ω::ConstantParam,duration::Real,params)
         error_or_warn(params.warn,"Rabi frequency drive Ω(t) must start and end with value 0.")
         return piecewise_linear(;clocks=Float64[0.0,duration],values=Float64[Ω,Ω])
     else
-        throw(ErrorException("Rabi field amplitude must be global drive."))
+        error("Rabi field amplitude must be global drive.")
     end
 end
 

--- a/lib/BloqadeSchema/src/parse.jl
+++ b/lib/BloqadeSchema/src/parse.jl
@@ -54,7 +54,7 @@ function discretize_with_warn(wf::Waveform,warn::Bool,max_slope::Real,min_step::
             )
             return new_wf
         else
-            error(e.msg)
+            rethrow(e)
         end
     end
 end

--- a/lib/BloqadeSchema/src/types.jl
+++ b/lib/BloqadeSchema/src/types.jl
@@ -88,6 +88,9 @@ end
     Time resolution : 1e-9 s
     Time step minimum : 1e-8 s
     """
+    
+    atom_position_resolution::Float64 = 0.1e-6
+
     rabi_frequency_amplitude_maximum::Float64 = 0.0
     rabi_frequency_amplitude_minimum::Float64 = 25.0e6
     rabi_frequency_amplitude_resolution::Float64 = 400.0
@@ -114,6 +117,7 @@ end
     n_shots::Int = 1
 
     warn::Bool = false
+    discretize::Bool = true
 end
 
 @option struct ShotOutput <: QuEraSchema

--- a/lib/BloqadeSchema/test/execute.jl
+++ b/lib/BloqadeSchema/test/execute.jl
@@ -14,15 +14,13 @@ using JSON
     params = BloqadeSchema.SchemaConversionParams()
 
 check_atom_res(x) = all(BloqadeSchema.check_resolution.(params.atom_position_resolution,x))
-    check_clock_res = x->all(BloqadeSchema.check_resolution.(params.rabi_time_resolution,x))
-    check_Δ_res = x->all(BloqadeSchema.check_resolution.(params.rabi_detuning_resolution,x))
-    check_Δi_res = x->all(BloqadeSchema.check_resolution.(params.rabi_detuning_local_resolution,x))
-    check_ϕ_res = x->all(BloqadeSchema.check_resolution.(params.rabi_frequency_phase_resolution,x))
-    check_Ω_res = x->all(BloqadeSchema.check_resolution.(params.rabi_frequency_amplitude_resolution,x))
+    check_clock_res(x) = all(BloqadeSchema.check_resolution.(params.rabi_time_resolution,x))
+    check_Δ_res(x) = all(BloqadeSchema.check_resolution.(params.rabi_detuning_resolution,x))
+    check_Δi_res(x) = all(BloqadeSchema.check_resolution.(params.rabi_detuning_local_resolution,x))
+    check_ϕ_res(x) = all(BloqadeSchema.check_resolution.(params.rabi_frequency_phase_resolution,x))
+    check_Ω_res(x) = all(BloqadeSchema.check_resolution.(params.rabi_frequency_amplitude_resolution,x))
 
-    for Ω in values
-        for ϕ in values
-            for Δ in values
+    for Ω in values, ϕ in values, Δ in values
                 if any((f isa BloqadeSchema.DynamicParam) for f in [ϕ,Ω,Δ])
                     H = rydberg_h(atoms;Ω=Ω,Δ=Δ,ϕ=ϕ)
                     j = BloqadeSchema.to_json(H,waveform_tolerance=1e-2,warn=true,discretize=true)

--- a/lib/BloqadeSchema/test/execute.jl
+++ b/lib/BloqadeSchema/test/execute.jl
@@ -13,7 +13,7 @@ using JSON
     values = [1.0,constant(;duration=T,value=1.0),Waveform(t->sin(2π*t/T)^2,T)]
     params = BloqadeSchema.SchemaConversionParams()
 
-    check_atom_res = x->all(BloqadeSchema.check_resolution.(params.atom_position_resolution,x))
+check_atom_res(x) = all(BloqadeSchema.check_resolution.(params.atom_position_resolution,x))
     check_clock_res = x->all(BloqadeSchema.check_resolution.(params.rabi_time_resolution,x))
     check_Δ_res = x->all(BloqadeSchema.check_resolution.(params.rabi_detuning_resolution,x))
     check_Δi_res = x->all(BloqadeSchema.check_resolution.(params.rabi_detuning_local_resolution,x))

--- a/lib/BloqadeSchema/test/execute.jl
+++ b/lib/BloqadeSchema/test/execute.jl
@@ -13,7 +13,7 @@ using JSON
     values = [1.0,constant(;duration=T,value=1.0),Waveform(t->sin(2π*t/T)^2,T)]
     params = BloqadeSchema.SchemaConversionParams()
 
-check_atom_res(x) = all(BloqadeSchema.check_resolution.(params.atom_position_resolution,x))
+    check_atom_res(x) = all(BloqadeSchema.check_resolution.(params.atom_position_resolution,x))
     check_clock_res(x) = all(BloqadeSchema.check_resolution.(params.rabi_time_resolution,x))
     check_Δ_res(x) = all(BloqadeSchema.check_resolution.(params.rabi_detuning_resolution,x))
     check_Δi_res(x) = all(BloqadeSchema.check_resolution.(params.rabi_detuning_local_resolution,x))
@@ -21,35 +21,33 @@ check_atom_res(x) = all(BloqadeSchema.check_resolution.(params.atom_position_res
     check_Ω_res(x) = all(BloqadeSchema.check_resolution.(params.rabi_frequency_amplitude_resolution,x))
 
     for Ω in values, ϕ in values, Δ in values
-                if any((f isa BloqadeSchema.DynamicParam) for f in [ϕ,Ω,Δ])
-                    H = rydberg_h(atoms;Ω=Ω,Δ=Δ,ϕ=ϕ)
-                    j = BloqadeSchema.to_json(H,waveform_tolerance=1e-2,warn=true,discretize=true)
-                    t = Configurations.from_dict(BloqadeSchema.TaskSpecification, JSON.parse(j))
+        if any((f isa BloqadeSchema.DynamicParam) for f in [ϕ,Ω,Δ])
+            H = rydberg_h(atoms;Ω=Ω,Δ=Δ,ϕ=ϕ)
+            j = BloqadeSchema.to_json(H,waveform_tolerance=1e-2,warn=true,discretize=true)
+            t = Configurations.from_dict(BloqadeSchema.TaskSpecification, JSON.parse(j))
 
-                    sites = [site for (i,site) in enumerate(t.lattice.sites) if t.lattice.filling[i] == 1]
-                    
-                    rabi_freq_amp = t.effective_hamiltonian.rydberg.rabi_frequency_amplitude.global_value
-                    rabi_freq_phase = t.effective_hamiltonian.rydberg.rabi_frequency_phase.global_value
-                    detuning_global = t.effective_hamiltonian.rydberg.detuning.global_value
-                    detuning_local = t.effective_hamiltonian.rydberg.detuning.local_value
+            sites = [site for (i,site) in enumerate(t.lattice.sites) if t.lattice.filling[i] == 1]
+            
+            rabi_freq_amp = t.effective_hamiltonian.rydberg.rabi_frequency_amplitude.global_value
+            rabi_freq_phase = t.effective_hamiltonian.rydberg.rabi_frequency_phase.global_value
+            detuning_global = t.effective_hamiltonian.rydberg.detuning.global_value
+            detuning_local = t.effective_hamiltonian.rydberg.detuning.local_value
 
-                    @test all(check_atom_res(s) for s in sites)
-                    @test check_clock_res(rabi_freq_phase.times)
-                    @test check_clock_res(rabi_freq_amp.times)
-                    @test check_clock_res(detuning_global.times)
-                    @test check_ϕ_res(rabi_freq_phase.values)
-                    @test check_Ω_res(rabi_freq_amp.values)
-                    @test check_Δ_res(detuning_global.values)
+            @test all(check_atom_res(s) for s in sites)
+            @test check_clock_res(rabi_freq_phase.times)
+            @test check_clock_res(rabi_freq_amp.times)
+            @test check_clock_res(detuning_global.times)
+            @test check_ϕ_res(rabi_freq_phase.values)
+            @test check_Ω_res(rabi_freq_amp.values)
+            @test check_Δ_res(detuning_global.values)
 
-                    if !isnothing(detuning_local)
-                        @test check_clock_res(detuning_local.times)
-                        @test check_Δ_res(detuning_local.values)
-                        @test check_Δi_res(detuning_local.lattice_site_coefficients)                  
-                    end
-
-
-                end
+            if !isnothing(detuning_local)
+                @test check_clock_res(detuning_local.times)
+                @test check_Δ_res(detuning_local.values)
+                @test check_Δi_res(detuning_local.lattice_site_coefficients)                  
             end
+
+
         end
     end
 

--- a/lib/BloqadeSchema/test/execute.jl
+++ b/lib/BloqadeSchema/test/execute.jl
@@ -6,16 +6,50 @@ using JSON
 
 
 @testset "to_schema" begin
-    T = 4
-    atoms = [(i,0) for i in 1:10]
+    T = 2
+    atoms = [(π*i,0) for i in 1:10]
 
-    values = [1.0,nothing,Waveform(t->sin(2π*t/T)^2,T/2)]
+    # values = [1.0,nothing,Waveform(t->sin(2π*t/T)^2,T/2)]
+    values = [1.0,constant(;duration=T,value=1.0),Waveform(t->sin(2π*t/T)^2,T)]
+    params = BloqadeSchema.SchemaConversionParams()
+
+    check_atom_res = x->all(BloqadeSchema.check_resolution.(params.atom_position_resolution,x))
+    check_clock_res = x->all(BloqadeSchema.check_resolution.(params.rabi_time_resolution,x))
+    check_Δ_res = x->all(BloqadeSchema.check_resolution.(params.rabi_detuning_resolution,x))
+    check_Δi_res = x->all(BloqadeSchema.check_resolution.(params.rabi_detuning_local_resolution,x))
+    check_ϕ_res = x->all(BloqadeSchema.check_resolution.(params.rabi_frequency_phase_resolution,x))
+    check_Ω_res = x->all(BloqadeSchema.check_resolution.(params.rabi_frequency_amplitude_resolution,x))
+
     for Ω in values
         for ϕ in values
             for Δ in values
                 if any((f isa BloqadeSchema.DynamicParam) for f in [ϕ,Ω,Δ])
                     H = rydberg_h(atoms;Ω=Ω,Δ=Δ,ϕ=ϕ)
-                    h = BloqadeSchema.to_json(H,waveform_tolerance=1e-2,warn=true)
+                    j = BloqadeSchema.to_json(H,waveform_tolerance=1e-2,warn=true,discretize=true)
+                    t = Configurations.from_dict(BloqadeSchema.TaskSpecification, JSON.parse(j))
+
+                    sites = [site for (i,site) in enumerate(t.lattice.sites) if t.lattice.filling[i] == 1]
+                    
+                    rabi_freq_amp = t.effective_hamiltonian.rydberg.rabi_frequency_amplitude.global_value
+                    rabi_freq_phase = t.effective_hamiltonian.rydberg.rabi_frequency_phase.global_value
+                    detuning_global = t.effective_hamiltonian.rydberg.detuning.global_value
+                    detuning_local = t.effective_hamiltonian.rydberg.detuning.local_value
+
+                    @test all(check_atom_res(s) for s in sites)
+                    @test check_clock_res(rabi_freq_phase.times)
+                    @test check_clock_res(rabi_freq_amp.times)
+                    @test check_clock_res(detuning_global.times)
+                    @test check_ϕ_res(rabi_freq_phase.values)
+                    @test check_Ω_res(rabi_freq_amp.values)
+                    @test check_Δ_res(detuning_global.values)
+
+                    if !isnothing(detuning_local)
+                        @test check_clock_res(detuning_local.times)
+                        @test check_Δ_res(detuning_local.values)
+                        @test check_Δi_res(detuning_local.lattice_site_coefficients)                  
+                    end
+
+
                 end
             end
         end

--- a/lib/BloqadeSchema/test/parse.jl
+++ b/lib/BloqadeSchema/test/parse.jl
@@ -25,6 +25,19 @@ using Unitful: μs, s, MHz, rad
 
 end
 
+@testset "set_resolution" begin
+
+    examples = [
+        (1,10.123,10.0),
+        (0.1,10.1256,10.1),
+        (0.01,10.1256,10.13),
+    ]
+    for (δ,val,res) in examples
+        @test BloqadeSchema.set_resolution(val,δ) == res
+    end
+
+end
+
 @testset "parse_dynamic_rydberg_Ω" begin
 
 

--- a/lib/BloqadeSchema/test/runtests.jl
+++ b/lib/BloqadeSchema/test/runtests.jl
@@ -2,12 +2,14 @@ using BloqadeSchema
 using Configurations
 using Test
 
-@testset "execute" begin
-    include("execute.jl")
-end
+
 
 @testset "parse" begin
     include("parse.jl")
+end
+
+@testset "execute" begin
+    include("execute.jl")
 end
 
 # @testset "serialize" begin


### PR DESCRIPTION
this PR I implement some functions to round the Schema values to the specified resolution. The default behavior is to do this rounding automatically. the rounding can be disables with the flag `discretize=false` in the `to_json` function. 