### PR TITLE
Vector of Waveform typing issues translating to schema.

### DIFF
--- a/lib/BloqadeSchema/src/parse.jl
+++ b/lib/BloqadeSchema/src/parse.jl
@@ -189,7 +189,6 @@ function parse_dynamic_rydberg_Ω(Ω::DynamicParam,params;duration=nothing)
             error_or_warn(params.warn,"Rabi frequency drive Ω(t) must start and end with value 0.")
         end
 
-        println(Ω_max_slope,"\t\t",min_step,"\t\t",params.waveform_tolerance)
         Ω = discretize_with_warn(Ω,params.warn,Ω_max_slope,min_step,params.waveform_tolerance)
 
         return Ω,duration

--- a/lib/BloqadeSchema/src/types.jl
+++ b/lib/BloqadeSchema/src/types.jl
@@ -2,7 +2,12 @@ using GarishPrint
 
 
 const ConstantParam = Union{Real,Nothing,Vector{<:Real}}
-const DynamicParam = Union{Waveform{F,T} where {F,T<:Real},Vector{Waveform{F,T}} where {F,T<:Real} }
+const DynamicParam = Union{
+        Waveform{F,T} where {F,T<:Real},
+        Vector{Waveform{F,T}} where {F,T<:Real},
+        Vector{Waveform{F,T} where F} where T<:Real,
+        Vector{Waveform{F,T}} where {F,T}
+    }
 
 
 abstract type QuEraSchema end

--- a/lib/BloqadeSchema/test/execute.jl
+++ b/lib/BloqadeSchema/test/execute.jl
@@ -10,7 +10,13 @@ using JSON
     atoms = [(π*i,0) for i in 1:10]
 
     # values = [1.0,nothing,Waveform(t->sin(2π*t/T)^2,T/2)]
-    values = [1.0,constant(;duration=T,value=1.0),Waveform(t->sin(2π*t/T)^2,T)]
+
+    wf1 = Waveform(t->sin(π*t/T)^2,T)
+    wf2 = Waveform(t->cos(π*t/T),T)
+    wfs_mixed = [(i%2==0 ? 1 : 0.1)*wf1 + wf2 for i in 1:length(atoms)]
+    wfs_same = [i*wf1+wf2 for i in 1:length(atoms)]
+    scalar_values = [1.0,nothing,constant(;duration=T,value=1.0),wf1]
+    all_values = [1.0,nothing,constant(;duration=T,value=1.0),wf1,wfs_mixed,wfs_same]
     params = BloqadeSchema.SchemaConversionParams()
 
     check_atom_res(x) = all(BloqadeSchema.check_resolution.(params.atom_position_resolution,x))
@@ -20,7 +26,7 @@ using JSON
     check_ϕ_res(x) = all(BloqadeSchema.check_resolution.(params.rabi_frequency_phase_resolution,x))
     check_Ω_res(x) = all(BloqadeSchema.check_resolution.(params.rabi_frequency_amplitude_resolution,x))
 
-    for Ω in values, ϕ in values, Δ in values
+    for Ω in scalar_values, ϕ in scalar_values, Δ in all_values
         if any((f isa BloqadeSchema.DynamicParam) for f in [ϕ,Ω,Δ])
             H = rydberg_h(atoms;Ω=Ω,Δ=Δ,ϕ=ϕ)
             j = BloqadeSchema.to_json(H,waveform_tolerance=1e-2,warn=true,discretize=true)


### PR DESCRIPTION
* fixing issue with type errors in parsing function. The issue was caused by the following waveform:
```Julia
T=1/8
epsilon = 0.01
Δ_global = piecewise_linear(clocks=[0.0, epsilon, T+ epsilon , T+2*epsilon], values= 2π*[0.0,  -9, -9,  0])
Δ_local = piecewise_linear(clocks=[0.0, epsilon, T+ epsilon , T+2*epsilon], values= 2π*[0.0, 9, 9,  0])
Δt = map(1:length(atoms)) do idx
    if idx == floor(Int, N/2)+1
        Δ_global + 1* Δ_local
    else
        Δ_global + 0.1* Δ_local
    end
end ;
```
* Not sure if this takes care of all possible cases but the types just from examples I have come across it seems like these types  vectors of Waveforms is as follows:

```Julia
Vector{Waveform{F,T} where {F,T}}
Vector{Waveform{F,T} where F} where T
Vector{Waveform{F,T}} where {F,T}
```
@Roger-luo Maybe you can point me to a reference where this is explained better. I've gone through the Julia docs but the section of this is not very extensive. 


* added more test cases to check for local detuning pattern to try and catch these cases.