### PR TITLE
Bug in piecewise_linear_interpolate.

### DIFF
--- a/lib/BloqadeSchema/src/parse.jl
+++ b/lib/BloqadeSchema/src/parse.jl
@@ -39,20 +39,20 @@ function get_rydberg_params(h::BloqadeExpr.RydbergHamiltonian)
     return (h.rydberg_term.atoms,ϕ,Ω,Δ)
 end
 
-function discretize_with_warn(wf::Waveform,warn::Bool,max_slope::Real,min_step::Real,tol::Real)
+function discretize_with_warn(wf::Waveform,warn::Bool,max_slope::Real,min_step::Real,atol::Real)
     try
         new_wf = BloqadeWaveforms.piecewise_linear_interpolate(wf,
             max_slope=max_slope,
             min_step=min_step,
-            tol=tol,
+            atol=atol,
         )
         return new_wf
     catch e
         if e isa ErrorException && warn
             @warn e.msg
-            new_wf = if tol > 0
+            new_wf = if atol > 0
                 BloqadeWaveforms.piecewise_linear_interpolate(wf,
-                    tol=tol,
+                    atol=atol,
                 )
             else
                 BloqadeWaveforms.piecewise_linear_interpolate(wf,

--- a/lib/BloqadeWaveforms/src/interpolate.jl
+++ b/lib/BloqadeWaveforms/src/interpolate.jl
@@ -5,14 +5,14 @@
 function piecewise_linear_interpolate(wf::Waveform{PiecewiseLinear{T,Interp},T}; 
     max_slope::Real=Inf64, 
     min_step::Real=0.0, 
-    tol::Real = 1.0e-5) where {T<:Real,Interp}
+    atol::Real = 1.0e-5) where {T<:Real,Interp}
 
-    if tol < 0
+    if atol < 0
         @warn "negative tolerance provided, taking absolute value."
-        tol *= -1
+        atol *= -1
     end
 
-    if tol == 0 && ( max_slope == Inf64 || min_step == 0)
+    if atol == 0 && ( max_slope == Inf64 || min_step == 0)
         error("Interpolation requires either a tolerance constraint or a slope and step constraint.")
     end
 
@@ -47,14 +47,14 @@ end
 function piecewise_linear_interpolate(wf::Waveform{PiecewiseConstant{T},T}; 
     max_slope::Real=Inf64, 
     min_step::Real=0.0, 
-    tol::Real = 1.0e-5) where {T<:Real}
+    atol::Real = 1.0e-5) where {T<:Real}
 
-    if tol < 0
+    if atol < 0
         @warn "negative tolerance provided, taking absolute value."
-        tol *= -1
+        atol *= -1
     end
 
-    if tol == 0 && ( max_slope == Inf64 || min_step == 0)
+    if atol == 0 && ( max_slope == Inf64 || min_step == 0)
         error("Interpolation requires either a tolerance constraint or a slope and step constraint.")
     end
 
@@ -64,7 +64,7 @@ function piecewise_linear_interpolate(wf::Waveform{PiecewiseConstant{T},T};
     values = Float64[v[1]]
 
 
-    itol = tol / (length(v) - 1) # distribute error over each step
+    itol = atol / (length(v) - 1) # distribute error over each step
 
     @inbounds for i in 1:length(v)-1
         t0 = c[i+1]        
@@ -118,19 +118,19 @@ Function which takes a waveform and translates it to a linear interpolation subj
 # Keyword Arguments
 - `min_step`: minimum possible step used in interpolation
 - `max_slope`: Maximum possible slope used in interpolation
-- `tol`: tolerance of interpolation, this is a bound to the area between the linear interpolation and the waveform.
+- `atol`: tolerance of interpolation, this is a bound to the area between the linear interpolation and the waveform.
 """
 function piecewise_linear_interpolate(wf::Waveform; 
     max_slope::Real=Inf64, 
     min_step::Real=0.0, 
-    tol::Real = 1.0e-5)
+    atol::Real = 1.0e-5)
     
-    if tol < 0
+    if atol < 0
         @warn "negative tolerance provided, taking absolute value."
-        tol *= -1
+        atol *= -1
     end
 
-    if tol == 0 && ( max_slope == Inf64 || min_step == 0)
+    if atol == 0 && ( max_slope == Inf64 || min_step == 0)
         error("Interpolation requires either a tolerance constraint or a slope and step constraint.")
     end
     
@@ -150,7 +150,7 @@ function piecewise_linear_interpolate(wf::Waveform;
 
         area,_ = quadgk(t -> abs.(lin_f(t) .- wf_wrapper(t)),lb,ub,atol=eps())
 
-        error_bound = max(tol*max(tol,interval),eps())
+        error_bound = max(atol*max(atol,interval),eps())
 
         if area*wf.duration > error_bound
             mid = (ub+lb)/2
@@ -160,10 +160,10 @@ function piecewise_linear_interpolate(wf::Waveform;
             # only throw error if tolerance is non-zero
             # if tolerance is 0 simply stop adding to stack
             if next_slope > max_slope 
-                tol > 0 && error("Requested tolerance for interpolation violates the slope constraint.")
+                atol > 0 && error("Requested tolerance for interpolation violates the slope constraint.")
                 push!(intervals,(lb,ub,f_lb,slope))
             elseif interval < 2*min_step
-                tol > 0 && error("Requested tolerance for interpolation violates the step size constraint.")
+                atol > 0 && error("Requested tolerance for interpolation violates the step size constraint.")
                 push!(intervals,(lb,ub,f_lb,slope))
             else
                 push!(stack,(mid,ub))

--- a/lib/BloqadeWaveforms/src/interpolate.jl
+++ b/lib/BloqadeWaveforms/src/interpolate.jl
@@ -148,8 +148,9 @@ function piecewise_linear_interpolate(wf::Waveform;
 
         lin_f = t -> slope .* (t .- lb) .+ f_lb
 
-        area,_ = quadgk(t -> abs.(lin_f(t) .- wf_wrapper(t)),lb,ub)
-        error_bound = tol*max(tol,interval)
+        area,_ = quadgk(t -> abs.(lin_f(t) .- wf_wrapper(t)),lb,ub,atol=eps())
+
+        error_bound = max(tol*max(tol,interval),eps())
 
         if area*wf.duration > error_bound
             mid = (ub+lb)/2
@@ -160,8 +161,10 @@ function piecewise_linear_interpolate(wf::Waveform;
             # if tolerance is 0 simply stop adding to stack
             if next_slope > max_slope 
                 tol > 0 && error("Requested tolerance for interpolation violates the slope constraint.")
+                push!(intervals,(lb,ub,f_lb,slope))
             elseif interval < 2*min_step
                 tol > 0 && error("Requested tolerance for interpolation violates the step size constraint.")
+                push!(intervals,(lb,ub,f_lb,slope))
             else
                 push!(stack,(mid,ub))
                 push!(stack,(lb,mid))

--- a/lib/BloqadeWaveforms/test/interpolate.jl
+++ b/lib/BloqadeWaveforms/test/interpolate.jl
@@ -66,3 +66,9 @@ end
 
 
 end
+
+@testset "constraint terminated" begin
+    wf = Waveform(t->t^2,1)
+    new_wf = piecewise_linear_interpolate(wf,tol=0,max_slope=100,min_step=1e-5)
+    @test norm(wf - new_wf) < 1e-3
+end

--- a/lib/BloqadeWaveforms/test/interpolate.jl
+++ b/lib/BloqadeWaveforms/test/interpolate.jl
@@ -16,8 +16,8 @@ warn_msg = "negative tolerance provided, taking absolute value."
     slope_msg = "Waveform slope larger than constraint."
     step_msg = "Waveform step smaller than constraint."
     # test_log instead of test_warn for julia 1.6
-    @test_logs (:warn,warn_msg) piecewise_linear_interpolate(wf;tol=-1e-5)
-    @test_throws ErrorException piecewise_linear_interpolate(wf;tol=0)
+    @test_logs (:warn,warn_msg) piecewise_linear_interpolate(wf;atol=-1e-5)
+    @test_throws ErrorException piecewise_linear_interpolate(wf;atol=0)
     @test_throws ErrorException piecewise_linear_interpolate(wf;min_step = 10.0)
     @test_throws ErrorException piecewise_linear_interpolate(wf;max_slope = 0.1)
 
@@ -28,40 +28,40 @@ end
 
     pwc_step_msg = "Distance between steps in piecewise constant waveform are too small to convert to piecewise linear."
 
-    new_wf = piecewise_linear_interpolate(wf,tol=1e-3) # no constraints
+    new_wf = piecewise_linear_interpolate(wf,atol=1e-3) # no constraints
     @test new_wf == piecewise_linear(
         clocks=[0.0,1.9995,2.0005,2.999,3.001,4.0],
         values=[0.0,0.0,2.0,2.0,1.0,1.0]
         )
 
-    @test_logs (:warn,warn_msg) piecewise_linear_interpolate(wf;tol=-1e-5)
-    @test_throws ErrorException piecewise_linear_interpolate(wf;tol=0)
+    @test_logs (:warn,warn_msg) piecewise_linear_interpolate(wf;atol=-1e-5)
+    @test_throws ErrorException piecewise_linear_interpolate(wf;atol=0)
     @test_throws ErrorException piecewise_linear_interpolate(wf;min_step = 1.0)
     @test_throws ErrorException piecewise_linear_interpolate(wf;max_slope = 1.0)
 
 
     wf = piecewise_constant(;clocks = [0.0, 1.0, 2.0], values = [0.0, 20.0])
-    @test_throws ErrorException piecewise_linear_interpolate(wf;tol=0,max_slope=5.0,min_step=0.1)
+    @test_throws ErrorException piecewise_linear_interpolate(wf;atol=0,max_slope=5.0,min_step=0.1)
 
 end
 
 @testset "general waveform" begin
     f_list = [(t->t^2,10.0),(t->sin(t),2π),(t->t*sin(t^2),10.0),(t->sqrt(t)*sign(sin(t)),2π)]
-    tol=1e-3
+    atol=1e-3
     for (f,duration) in f_list
         wf = Waveform(f,duration)
-        new_wf = piecewise_linear_interpolate(wf;tol=tol)
+        new_wf = piecewise_linear_interpolate(wf;atol=atol)
 
 
-        @test isapprox(wf,new_wf,atol=tol)
+        @test isapprox(wf,new_wf,atol=atol)
     end
 
     wf = Waveform(t->t^2,2)
 
-    @test_logs (:warn,warn_msg) piecewise_linear_interpolate(wf;tol=-1e-5)
+    @test_logs (:warn,warn_msg) piecewise_linear_interpolate(wf;atol=-1e-5)
     @test_throws ErrorException piecewise_linear_interpolate(wf;max_slope = 2.0)
     @test_throws ErrorException piecewise_linear_interpolate(wf;min_step = 0.1)
-    @test_throws ErrorException piecewise_linear_interpolate(wf;tol=0)
+    @test_throws ErrorException piecewise_linear_interpolate(wf;atol=0)
 
 
 
@@ -69,6 +69,6 @@ end
 
 @testset "constraint terminated" begin
     wf = Waveform(t->t^2,1)
-    new_wf = piecewise_linear_interpolate(wf,tol=0,max_slope=100,min_step=1e-5)
+    new_wf = piecewise_linear_interpolate(wf,atol=0,max_slope=100,min_step=1e-5)
     @test norm(wf - new_wf) < 1e-3
 end


### PR DESCRIPTION
fixing bug related to terminating linear interpolation when constraint is met. Also renaming `tol` to `atol` to better reflect the behavior. 