### PR TITLE
Export triweight kernel

### DIFF
--- a/lib/BloqadeWaveforms/src/smooth.jl
+++ b/lib/BloqadeWaveforms/src/smooth.jl
@@ -3,7 +3,7 @@ Built-in kernel functions.
 """
 module Kernels
 
-export gaussian, triangle, uniform, parabolic, biweight, tricube, cosine, logistic, sigmoid
+export gaussian, triangle, uniform, parabolic, biweight, triweight, tricube, cosine, logistic, sigmoid
 
 # kernels
 # https://en.wikipedia.org/wiki/Kernel_(statistics)#Kernel_functions_in_common_use

--- a/lib/BloqadeWaveforms/test/smooth.jl
+++ b/lib/BloqadeWaveforms/test/smooth.jl
@@ -9,6 +9,8 @@ using BloqadeWaveforms: edge_pad
 
     @test biweight(0.1) ≈ 0.91884375
     @test biweight(1.1) ≈ 0.0
+    @test triweight(0.1) ≈ 1.06126453125
+    @test triweight(1.1) ≈ 0.0
     @test cosine(0.1) ≈ π / 4 * cos(π / 2 * 0.1)
     @test gaussian(0.1) ≈ 0.3969525474770118
     @test logistic(0.1) ≈ 0.24937604019289197


### PR DESCRIPTION
The Triweight kernel was already implemented, just needed to be exported. Added additional unit tests for it as well.