### PR TITLE
Fixed Typos

### DIFF
--- a/docs/src/contrib.md
+++ b/docs/src/contrib.md
@@ -85,7 +85,7 @@ looking up dependencies in `lib` in one's `Project.toml` file,
 will `dev` all the Bloqade dependencies in your environment.
 
 See also [Modifying A Dependency](https://pkgdocs.julialang.org/v1/getting-started/#Modifying-A-Dependency)
-for more detailed explainations.
+for more detailed explanations.
 
 ### Create New Examples
 

--- a/docs/src/hamiltonians.md
+++ b/docs/src/hamiltonians.md
@@ -140,7 +140,7 @@ space = blockade_subspace(atoms, 7.5)
 
 The above code means that the blockade subspace only includes states where there is only one Rydberg excitation 
 within the distance of 7.5 μm, which we call the subspace radius ``R_s``. If we have a chain of atoms separated by 5.72 μm, the blockade subspace 
-does not contain states with nearest-neighbor atoms being simutaneously excited to the Rydberg state `` | r \rangle ``.
+does not contain states with nearest-neighbor atoms being simultaneously excited to the Rydberg state `` | r \rangle ``.
 
 Once we have defined the space, we can convert the Hamiltonian to a matrix in a subspace basis via the codes below:
 

--- a/docs/src/julia.md
+++ b/docs/src/julia.md
@@ -30,7 +30,7 @@ and a guide for learning more about Julia and advanced usage.
 
 !!! info
 
-    Multi-stage programming (MSP) is a variety of metaprogramming in which compilation is divided into a series of intermediate phases, allowing typesafe run-time code generation. Statically defined types are used to verify that dynamically constructed types are valid and do not violate the type system. 
+    Multi-stage programming (MSP) is a variety of metaprogramming in which compilation is divided into a series of intermediate phases, allowing type-safe run-time code generation. Statically defined types are used to verify that dynamically constructed types are valid and do not violate the type system. 
 
     -- Wikipedia
 

--- a/docs/src/lattices.md
+++ b/docs/src/lattices.md
@@ -63,7 +63,7 @@ lattice_vectors(chain)
 lattice_sites(chain)
 ```
 
-Once we have defined certain lattice shapes (which have fixed lattice vectors and site positions in the unit cell), we can generate the atom positons by 
+Once we have defined certain lattice shapes (which have fixed lattice vectors and site positions in the unit cell), we can generate the atom positions by 
 specifying the number of atoms and the scale size of the lattice. 
 This is done by using the function [`generate_sites`](@ref) , which will return a [`AtomList`](@ref) instance containing the coordinates of each atom, e.g.:  
 
@@ -186,7 +186,7 @@ One can select and display these atoms with the correct labeling by typing:
 Bloqade.plot(sorted_atoms[neighbors[2]]; texts=string.(neighbors[2]))
 ```
 
-It shows the correct second nearest neigbors of the site 5.
+It shows the correct second nearest neighbors of the site 5.
 One can check the docstring of [`Bloqade.plot`](@ref) to know more about how to customize lattice visualization.
 
 ## References

--- a/docs/src/subspace.md
+++ b/docs/src/subspace.md
@@ -32,9 +32,9 @@ using Bloqade
 atoms = generate_sites(SquareLattice(), 3, 3, scale=5.1)
 space = blockade_subspace(atoms, 5.2)
 ```
-We first created a ``3*3`` square lattice with nearest neighbor atoms seperated by ``5.1`` μm. 
+We first created a ``3*3`` square lattice with nearest neighbor atoms separated by ``5.1`` μm. 
 Then we have created a
-blockade subpace with the subspace radius, ``R_s``, being ``5.2`` μm. 
+blockade subspace with the subspace radius, ``R_s``, being ``5.2`` μm. 
 This means that if two atoms have a separation distance that is smaller than (or equal to)
 ``5.2`` μm, 
 then the blockade subspace does not contain states where both of them being in the Rydberg states.


### PR DESCRIPTION
Some small typos (just single word misspellings) were found in 
* contrib.md
* hamiltonians.md
* julia.md
* lattices.md
* subspace.md
and have been fixed