### PR TITLE
promote types for waveforms

### DIFF
--- a/lib/BloqadeWaveforms/src/waveform.jl
+++ b/lib/BloqadeWaveforms/src/waveform.jl
@@ -229,6 +229,8 @@ struct PiecewiseLinear{T<:Real,Interp}
     function PiecewiseLinear(clocks::Vector{<:Real}, values::Vector{<:Real})
         assert_clocks(clocks)
         length(clocks) == length(values) || throw(ArgumentError("expect clocks has the same length as values"))
+        T = promote_type(eltype(clocks), eltype(values))
+        clocks = Vector{T}(clocks); values = Vector{T}(values);
         interp = LinearInterpolation(clocks, values)
         return new{eltype(values),typeof(interp)}(clocks, values, interp)
     end
@@ -251,7 +253,8 @@ struct PiecewiseConstant{T<:Real}
     function PiecewiseConstant(clocks::Vector{<:Real}, values::Vector{<:Real})
         assert_clocks(clocks)
         length(clocks) == length(values) + 1 || throw(ArgumentError("expect clocks has one more element than values"))
-        return new{eltype(values)}(clocks, values)
+        T = promote_type(eltype(values), eltype(clocks))
+        return new{T}(clocks, values)
     end
 end
 

--- a/lib/BloqadeWaveforms/test/waveform.jl
+++ b/lib/BloqadeWaveforms/test/waveform.jl
@@ -70,6 +70,13 @@ end
         @test wf(100.0) ≈ 0.0011
         @test wf(200.0) ≈ 0.0021
     end
+
+    @testset "promote_type" begin
+        wf = piecewise_linear(clocks=[0,1.23], values= [0, 0])
+        @test eltype(wf) === Float64
+        wf = piecewise_constant(clocks=[0,1.23,1.5], values= [0, 0])
+        @test eltype(wf) === Float64
+    end
 end
 
 @testset "waveform + waveform" begin


### PR DESCRIPTION
`piecewise_xxx` should promote the types. originally found by @jon-wurtz 