### PR TITLE
change default solver, filter out illegal kw

### DIFF
--- a/lib/BloqadeMIS/src/subspace.jl
+++ b/lib/BloqadeMIS/src/subspace.jl
@@ -14,7 +14,7 @@ function independent_set_subspace(::Type{T}, graph::SimpleGraph) where T
     return create_subspace_from_mis(T, n, mis)
 end
 
-function independent_set_subspace(graph::SimpleGraph) where T
+function independent_set_subspace(graph::SimpleGraph)
     n = nv(graph)
     @assert n <= 128 "number of vertices in a graph is too large! $(n) > 128"
     independent_set_subspace(n > 64 ? Int128 : Int64, graph)

--- a/lib/BloqadeODE/src/BloqadeODE.jl
+++ b/lib/BloqadeODE/src/BloqadeODE.jl
@@ -9,7 +9,7 @@ using YaoSubspaceArrayReg
 @reexport using BloqadeExpr
 @reexport using OrdinaryDiffEq
 using BloqadeExpr: Hamiltonian
-using OrdinaryDiffEq: AutoSwitchCache
+using OrdinaryDiffEq: AutoSwitchCache, CompositeInterpolationData
 using LinearAlgebra
 
 using OrdinaryDiffEq:

--- a/lib/BloqadeODE/src/BloqadeODE.jl
+++ b/lib/BloqadeODE/src/BloqadeODE.jl
@@ -9,6 +9,7 @@ using YaoSubspaceArrayReg
 @reexport using BloqadeExpr
 @reexport using OrdinaryDiffEq
 using BloqadeExpr: Hamiltonian
+using OrdinaryDiffEq: AutoSwitchCache
 using LinearAlgebra
 
 using OrdinaryDiffEq:

--- a/lib/BloqadeODE/src/problem.jl
+++ b/lib/BloqadeODE/src/problem.jl
@@ -76,7 +76,7 @@ struct SchrodingerProblem{Reg,EquationType<:ODEFunction,uType,tType,Algo,Kwargs}
     p::Nothing # well make DiffEq happy
 end
 
-function SchrodingerProblem(reg::AbstractRegister, tspan, expr; algo=VCABM3(), kw...)
+function SchrodingerProblem(reg::AbstractRegister, tspan, expr; algo=AutoVern9(Rodas5()), kw...)
     nqudits(reg) == nqudits(expr) || throw(ArgumentError("number of qubits/sites does not match!"))
     # remove this after ArrayReg start using AbstractVector
     state = statevec(reg)

--- a/lib/BloqadeODE/test/forwarddiff.jl
+++ b/lib/BloqadeODE/test/forwarddiff.jl
@@ -21,6 +21,7 @@ end
 
 Random.seed!(42)
 xs = rand(5)
+
 Δ_ad = ForwardDiff.gradient(loss, xs)
 Δ_fd, = FiniteDifferences.grad(central_fdm(5, 1), loss, xs)
 


### PR DESCRIPTION
This PR filters out our custom option `algo` before forwarding kwargs to ODE solver. Also changes default solver to `AutoVern9(Rodas5())` to make the following example provided by @jon-wurtz having lower error

<details>
<summary>code</summary>

```julia
using BloqadeSchema
using BloqadeExpr
using BloqadeWaveforms
using JSON
using BloqadeODE
using Yao



function simulate(h;message="")
    if nqubits(h)==1
        
        reg = zero_state(nqubits(h)); # create fullspace register
        ev = SchrodingerProblem(reg, h.rabi_term.Ω.f.duration-1e-13, h;dt=1e-4) # the second input is the total time
        solve(ev, AutoVern9(Rodas5()))
        #println(message," Probability:",abs.(ev.reg.state).^2)
        return abs.(ev.reg.state).^2
    else
        #println("Too many qubits, not simulating")
        return [0.0,0.0]
    end
end

he = 75
ve = 100
# Generate a grid of atoms spaced 10um apart
atoms = []
dx = 12000
for i in range(0,floor(he/dx,digits=0))
    for j in range(0,floor(ve/dx,digits=0))
        push!(atoms, (i*dx, j*dx))
    end
end
println("Number of atoms:",size(atoms))

lattice = BloqadeSchema.Lattice(sites=atoms,filling=ones(size(atoms)))



# Jumping detuning from positive to negative.

Delta_ = LinRange(-20,20,1001)
data = []
for Delta in Delta_
    trise = 0.01
    Omega = 10.0
    Omega = round(Omega,digits=2)
    Delta = round(Delta,digits=2)

    delta_offset = 5.0

    Tevolve = pi/sqrt(Omega^2 + Delta^2)
    Tevolve += trise/2

    ϕ = piecewise_constant(clocks=[0,2*Tevolve], values= [0.0])
    Δ = piecewise_linear(clocks=[0,trise,Tevolve-trise/2,Tevolve+trise/2,2*Tevolve-trise,2*Tevolve], values=  [0.0,Delta+delta_offset,Delta+delta_offset,-Delta+delta_offset,-Delta+delta_offset,0.0])
    Ω = piecewise_linear(clocks=[0.0,trise,2*Tevolve-trise,2*Tevolve], values= [0,Omega,Omega,0])
    h = rydberg_h(atoms,ϕ=ϕ,Δ=Δ,Ω=Ω)
    append!(data, simulate(h,message="2 zigzag")[1])
end



using Plots
Delta_
data
plot(Delta_,data)
xlabel!("Detuning (MHz)")
ylabel!("Ground state probability")
```

</details>