### PR TITLE
fix floating point error

### DIFF
--- a/lib/BloqadeWaveforms/test/waveform.jl
+++ b/lib/BloqadeWaveforms/test/waveform.jl
@@ -224,4 +224,13 @@ end
     new_wf = append(start_wf,mid_wf,end_wf)
 
     @test new_wf ≈ target_wf
+
+    # check floating point error
+    wf = append(
+        piecewise_linear(clocks=[0.0,0.2],values=[0.0,0.0]),
+        piecewise_linear(clocks=[0.0,0.16], values = [0.1,0.1]),
+        piecewise_linear(clocks=[0.0,0.2], values=[0.0,0.0])
+    );
+
+    @test wf(0.56) ≈ 0.0
 end


### PR DESCRIPTION
tricky corner case found by @jon-wurtz , basically, due to floating point error 

```julia
julia> 0.56 - 0.36 > 0.2
true
```

thus it is out of bounds in interpolation. 