### PR TITLE
Fix kernel function documentation

### DIFF
--- a/docs/src/waveform.md
+++ b/docs/src/waveform.md
@@ -167,4 +167,14 @@ sinusoidal
 append
 smooth
 smooth(kernel, Xi::Vector, Yi::Vector, kernel_radius::Real)
+Kernels.biweight
+Kernels.cosine
+Kernels.gaussian
+Kernels.logistic
+Kernels.parabolic
+Kernels.sigmoid
+Kernels.triangle
+Kernels.tricube
+Kernels.triweight
+Kernels.uniform
 ```

--- a/lib/BloqadeWaveforms/src/smooth.jl
+++ b/lib/BloqadeWaveforms/src/smooth.jl
@@ -8,7 +8,17 @@ export gaussian, triangle, uniform, parabolic, biweight, triweight, tricube, cos
 # kernels
 # https://en.wikipedia.org/wiki/Kernel_(statistics)#Kernel_functions_in_common_use
 _in_radius(t, value) = abs(t) ≤ 1 ? value : zero(t)
+"""
+    gaussian(t)
+
+Gaussian kernel function for smoothing waveforms via [`smooth`](@ref)
+"""
 gaussian(t) = exp(-abs2(t) / 2) / sqrt(2π)
+"""
+    triangle(t)
+
+Triangle kernel function for smoothing waveforms via [`smooth`](@ref)
+"""
 triangle(t) = _in_radius(t, 1 - abs(t))
 
 function uniform(t::T) where {T}
@@ -17,13 +27,48 @@ function uniform(t::T) where {T}
     return T(abs(t) ≤ 1)
 end
 
+"""
+    parabolic(t)
+
+Parabolic kernel function for smoothing waveforms via [`smooth`](@ref)
+"""
 parabolic(t) = _in_radius(t, 3 / 4 * (1 - abs2(t)))
+"""
+    biweight(t)
+
+Biweight kernel function for smoothing waveforms via [`smooth`](@ref)
+"""
 biweight(t) = _in_radius(t, 15 / 16 * (1 - abs2(t))^2)
+"""
+    triweight(t)
+
+Biweight kernel function for smoothing waveforms via [`smooth`](@ref)
+"""
 triweight(t) = _in_radius(t, 35 / 32 * (1 - abs2(t))^3)
+"""
+    tricube(t)
+
+Tricube kernel function for smoothing waveforms via [`smooth`](@ref)
+"""
 tricube(t) = _in_radius(t, 70 / 81 * (1 - abs(t)^3)^3)
+"""
+    cosine(t)
+
+Cosine kernel function for smoothing waveforms via [`smooth`](@ref)
+"""
 cosine(t) = _in_radius(t, π / 4 * cos(π / 2 * t))
 # TODO: check numerical stability
+"""
+    logistic(t)
+
+Logistic kernel function for smoothing waveforms via [`smooth`](@ref)
+"""
 logistic(t) = 1 / (exp(t) + 2 + exp(-t))
+"""
+    simgoid(t)
+
+Sigmoid kernel funciton for smoothing waveforms via [`smooth`](@ref)
+"""
 sigmoid(t) = 2 / (π * (exp(t) + exp(-t)))
 
 end
@@ -135,7 +180,8 @@ $(
             !startswith(x, '_') &&
             !startswith(x, '#') &&
             !isequal(x, "Kernels") &&
-            !isequal(x, "eval")
+            !isequal(x, "eval") &&
+            !isequal(x, "include")
         end |> xs->map(x->string("[`", x, "`](@ref)"), xs), "; "
     )
 )

--- a/lib/BloqadeWaveforms/src/smooth.jl
+++ b/lib/BloqadeWaveforms/src/smooth.jl
@@ -15,7 +15,7 @@ Gaussian kernel function for smoothing waveforms via [`smooth`](@ref).
 
 The function is defined as:
 ```math
-f(t) = \\frac{1}{\\sqrt{2\\pi}}e^{-\\frac{1}{2}|t|^2}
+f(t) = \\frac{1}{\\sqrt{2π}}e^{-\\frac{1}{2}|t|^2}
 ```
 """
 gaussian(t) = exp(-abs2(t) / 2) / sqrt(2π)
@@ -28,7 +28,7 @@ The function is defined as:
 ```math
 f(t) = 1 - |t|
 ```
-where ``|t| \\leq 0``. Otherwise, ``f(t) = 0``
+where ``|t| ≤ 1``. Otherwise, ``f(t) = 0``
 """
 triangle(t) = _in_radius(t, 1 - abs(t))
 
@@ -37,7 +37,7 @@ triangle(t) = _in_radius(t, 1 - abs(t))
 
 Uniform kernel function for smoothing waveforms via [`smooth`](@ref)
 
-The function returns ``1`` for ``|t| \\leq 1``. Otherwise, it returns ``0``.
+The function returns ``1`` for ``|t| ≤ 1``. Otherwise, it returns ``0``.
 """
 function uniform(t::T) where {T}
     # we calculate the normalize factor
@@ -54,7 +54,7 @@ The function is defined as:
 ```math
 f(t) = \\frac{3}{4}(1 - |t|^2)
 ```
-when ``|t| \\leq 1``. Otherwise, ``f(t) = 0``.
+when ``|t| ≤ 1``. Otherwise, ``f(t) = 0``.
 """
 parabolic(t) = _in_radius(t, 3 / 4 * (1 - abs2(t)))
 """
@@ -66,7 +66,7 @@ The function is defined as:
 ```math 
 f(t) = \\frac{15}{16}(1 - |t|^2)^2
 ```
-when ``|t| \\leq 1``. Otherwise, ``f(t) = 0``.
+when ``|t| ≤ 1``. Otherwise, ``f(t) = 0``.
 """
 biweight(t) = _in_radius(t, 15 / 16 * (1 - abs2(t))^2)
 """
@@ -78,7 +78,7 @@ The function is defined as:
 ```math
 f(t) = \\frac{35}{32}(1 - |t|^2)^3
 ```
-when ``|t| \\leq 1``. Otherwise, ``f(t) = 0``.
+when ``|t| ≤ 1``. Otherwise, ``f(t) = 0``.
 """
 triweight(t) = _in_radius(t, 35 / 32 * (1 - abs2(t))^3)
 """
@@ -90,7 +90,7 @@ The function is defined as:
 ```math
 f(t) = \\frac{70}{81}(1 - |t|^3)^3
 ```
-when ``|t| \\leq 1``. Otherwise, ``f(t) = 0``.
+when ``|t| ≤ 1``. Otherwise, ``f(t) = 0``.
 """
 tricube(t) = _in_radius(t, 70 / 81 * (1 - abs(t)^3)^3)
 """
@@ -100,9 +100,9 @@ Cosine kernel function for smoothing waveforms via [`smooth`](@ref)
 
 The function is defined as:
 ```math
-f(t) = \\frac{\\pi}{4}\\cos\\left(\\frac{\\pi}{2}t\\right)
+f(t) = \\frac{π}{4}\\cos\\left(\\frac{π}{2}t\\right)
 ```
-when ``|t| \\leq 1``. Otherwise, ``f(t) = 0``.
+when ``|t| ≤ 1``. Otherwise, ``f(t) = 0``.
 """
 cosine(t) = _in_radius(t, π / 4 * cos(π / 2 * t))
 # TODO: check numerical stability

--- a/lib/BloqadeWaveforms/src/smooth.jl
+++ b/lib/BloqadeWaveforms/src/smooth.jl
@@ -11,16 +11,34 @@ _in_radius(t, value) = abs(t) ≤ 1 ? value : zero(t)
 """
     gaussian(t)
 
-Gaussian kernel function for smoothing waveforms via [`smooth`](@ref)
+Gaussian kernel function for smoothing waveforms via [`smooth`](@ref).
+
+The function is defined as:
+```math
+f(t) = \\frac{1}{\\sqrt{2\\pi}}e^{-\\frac{1}{2}|t|^2}
+```
 """
 gaussian(t) = exp(-abs2(t) / 2) / sqrt(2π)
 """
     triangle(t)
 
-Triangle kernel function for smoothing waveforms via [`smooth`](@ref)
+Triangle kernel function for smoothing waveforms via [`smooth`](@ref).
+
+The function is defined as:
+```math
+f(t) = 1 - |t|
+```
+where ``|t| \\leq 0``. Otherwise, ``f(t) = 0``
 """
 triangle(t) = _in_radius(t, 1 - abs(t))
 
+"""
+    uniform(t::T) where {T}
+
+Uniform kernel function for smoothing waveforms via [`smooth`](@ref)
+
+The function returns ``1`` for ``|t| \\leq 1``. Otherwise, it returns ``0``.
+"""
 function uniform(t::T) where {T}
     # we calculate the normalize factor
     # in smooth, no need to div by m
@@ -31,30 +49,60 @@ end
     parabolic(t)
 
 Parabolic kernel function for smoothing waveforms via [`smooth`](@ref)
+
+The function is defined as:
+```math
+f(t) = \\frac{3}{4}(1 - |t|^2)
+```
+when ``|t| \\leq 1``. Otherwise, ``f(t) = 0``.
 """
 parabolic(t) = _in_radius(t, 3 / 4 * (1 - abs2(t)))
 """
     biweight(t)
 
 Biweight kernel function for smoothing waveforms via [`smooth`](@ref)
+
+The function is defined as:
+```math 
+f(t) = \\frac{15}{16}(1 - |t|^2)^2
+```
+when ``|t| \\leq 1``. Otherwise, ``f(t) = 0``.
 """
 biweight(t) = _in_radius(t, 15 / 16 * (1 - abs2(t))^2)
 """
     triweight(t)
 
 Biweight kernel function for smoothing waveforms via [`smooth`](@ref)
+
+The function is defined as:
+```math
+f(t) = \\frac{35}{32}(1 - |t|^2)^3
+```
+when ``|t| \\leq 1``. Otherwise, ``f(t) = 0``.
 """
 triweight(t) = _in_radius(t, 35 / 32 * (1 - abs2(t))^3)
 """
     tricube(t)
 
 Tricube kernel function for smoothing waveforms via [`smooth`](@ref)
+
+The function is defined as:
+```math
+f(t) = \\frac{70}{81}(1 - |t|^3)^3
+```
+when ``|t| \\leq 1``. Otherwise, ``f(t) = 0``.
 """
 tricube(t) = _in_radius(t, 70 / 81 * (1 - abs(t)^3)^3)
 """
     cosine(t)
 
 Cosine kernel function for smoothing waveforms via [`smooth`](@ref)
+
+The function is defined as:
+```math
+f(t) = \\frac{\\pi}{4}\\cos\\left(\\frac{\\pi}{2}t\\right)
+```
+when ``|t| \\leq 1``. Otherwise, ``f(t) = 0``.
 """
 cosine(t) = _in_radius(t, π / 4 * cos(π / 2 * t))
 # TODO: check numerical stability
@@ -62,12 +110,22 @@ cosine(t) = _in_radius(t, π / 4 * cos(π / 2 * t))
     logistic(t)
 
 Logistic kernel function for smoothing waveforms via [`smooth`](@ref)
+
+The function is defined as:
+```math
+f(t) = \\frac{1}{e^{t} + 2 + e^{-t}}
+```
 """
 logistic(t) = 1 / (exp(t) + 2 + exp(-t))
 """
     simgoid(t)
 
 Sigmoid kernel funciton for smoothing waveforms via [`smooth`](@ref)
+
+The function is defined as:
+```math
+f(t) = \\frac{2}{\\pi (e^{t} + e^{-t})}
+```
 """
 sigmoid(t) = 2 / (π * (exp(t) + exp(-t)))
 
@@ -182,7 +240,7 @@ $(
             !isequal(x, "Kernels") &&
             !isequal(x, "eval") &&
             !isequal(x, "include")
-        end |> xs->map(x->string("[`", x, "`](@ref)"), xs), "; "
+        end |> xs->map(x->string("[`Kernels.", x, "`](@ref)"), xs), "; "
     )
 )
 


### PR DESCRIPTION
Adds documentation for the kernel functions that `smooth` uses. Should be considered in conjunction with #470 as well as resolving #428 