### PR TITLE
Adding BoundedLattice to Bloqade interface.

### DIFF
--- a/lib/BloqadeExpr/Project.toml
+++ b/lib/BloqadeExpr/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.8"
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 BitBasis = "50ba71b6-fa0f-514d-ae9a-0916efc90dcf"
+BloqadeLattices = "bd27d05e-4ce1-5e79-84dd-c5d7d508bbe4"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/lib/BloqadeExpr/src/BloqadeExpr.jl
+++ b/lib/BloqadeExpr/src/BloqadeExpr.jl
@@ -13,6 +13,7 @@ using Unitful: Quantity, NoUnits, MHz, µm, uconvert
 using InteractiveUtils: subtypes
 using Base.Cartesian: @nexprs
 using YaoBlocks: ChainBlock, PutBlock, TrivialGate, Subroutine, Scale, Daggered, Add, ControlBlock, TimeEvolution
+using BloqadeLattices: BoundedLattice, rydberg_interaction_matrix
 
 export rydberg_h,
     rydberg_h_3,

--- a/lib/BloqadeExpr/src/interface.jl
+++ b/lib/BloqadeExpr/src/interface.jl
@@ -5,6 +5,16 @@ const n = YaoBlocks.ConstGate.P1
 
 end
 
+function process_atom_positions(atom_positions)
+    if typeof(atom_positions) <: BoundedLattice
+        return atoms
+    else
+        return map(atom_positions) do pos
+            (pos...,)
+        end
+    end
+end
+
 """
     emulate!(prob)
 
@@ -79,9 +89,7 @@ function rydberg_h(atom_positions; C = 2π * 862690, Ω = nothing, ϕ = nothing,
 end
 
 function rydberg_h(atom_positions, C, Ω, ϕ, Δ)
-    positions = map(atom_positions) do pos
-        return (pos...,)
-    end
+    positions = process_atom_positions(atom_positions)
 
     nsites = length(positions)
     rydberg_term = RydInteract(positions, C)
@@ -133,9 +141,7 @@ function rydberg_h_3(atom_positions;
 end
 
 function rydberg_h_3(atom_positions, C, Ω_hf, ϕ_hf, Δ_hf, Ω_r, ϕ_r, Δ_r)
-    positions = map(atom_positions) do pos
-        return (pos...,)
-    end
+    positions = process_atom_positions(atom_positions)
 
     nsites = length(positions)
     rydberg_term = RydInteract(positions, C; nlevel = 3)

--- a/lib/BloqadeExpr/src/lower.jl
+++ b/lib/BloqadeExpr/src/lower.jl
@@ -220,13 +220,12 @@ end
 
 function YaoBlocks.Optimise.to_basictypes(ex::RydInteract{D}) where D
     nsites = length(ex.atoms)
-    # replace this code with function from V = BloqadeLattices.generate_interactions(ex.atoms,r -> ex.C/r^6)
+    V = rydberg_interaction_matrix(ex.atoms,ex.C)
     term = nothing
     op = (D == 2 ? ConstGate.P1 : N_r)
-    for i in 1:nsites, j in 1:i-1
+    for i in 1:nsites, j in i+1:nsites
         x, y = ex.atoms[i], ex.atoms[j]
-        # h = V[i,j]*kron(nsites, i => op, j => op)
-        h = ex.C / distance(x, y)^6 * kron(nsites, i => op, j => op)
+        h = V[i,j]*kron(nsites, i => op, j => op)
 
         if isnothing(term)
             term = h

--- a/lib/BloqadeExpr/src/types.jl
+++ b/lib/BloqadeExpr/src/types.jl
@@ -164,7 +164,7 @@ Type for Rydberg interactive term.
 - `C`: the interaction strength, default unit is `MHz⋅μm^6`. default value is `2π * 862690 * MHz*µm^6`.
 """
 Base.@kwdef struct RydInteract{D} <: AbstractTerm{D}
-    atoms::Vector
+    atoms::Union{Vector,BoundedLattice}
     C::Real = 2π * 862690
 
     function RydInteract{D}(atoms, C) where D


### PR DESCRIPTION
This PR we add the new `BoundedLattice` to describe the position of atoms inside the symbolic hamiltonian. On top of this we use the interface inside `BloqadeLattices` to generate the rydberg interaction matrix, in doing so, we have the ability to implement periodic boundary conditions on the level of the Hamiltonian. 