### PR TITLE
Create Bloqade interface for QMC-Hamiltonian

### DIFF
--- a/lib/BloqadeQMC/src/ising/Rydberg.jl
+++ b/lib/BloqadeQMC/src/ising/Rydberg.jl
@@ -166,4 +166,13 @@ end
 total_hx(H::Rydberg)::Float64 = sum(H.Ω) / 2
 haslongitudinalfield(H::AbstractRydberg) = !iszero(H.δ)
 
+function rydberg_QMC(atoms::AtomList{1, Float64}; C = 2π * 862690, Ω::Float64, Δ::Float64)  # intended to mimic the rydberg_h interface 
+    # revisit the argument types & site-dependent parameters
+    Ns = length(atoms)
+    V = rydberg_interaction_matrix(atoms, C)
+    ops, p, energy_shift = make_prob_vector(AbstractRydberg, V, Ω*ones(Ns), Δ*ones(Ns), epsilon=0.0)
+    op_sampler = ImprovedOperatorSampler(AbstractLTFIM, ops, p)
+    return Rydberg{typeof(op_sampler), typeof(V), typeof(Ω*ones(Ns)), typeof(Δ*ones(Ns)), typeof(atoms)}(op_sampler, V, Ω*ones(Ns), Δ*ones(Ns), atoms, energy_shift)
+end
+
 

--- a/lib/BloqadeQMC/src/ising/Rydberg.jl
+++ b/lib/BloqadeQMC/src/ising/Rydberg.jl
@@ -1,23 +1,36 @@
 using Base.Iterators
-
+using BloqadeLattices: rydberg_interaction_matrix, AtomList
 
 abstract type AbstractRydberg{O <: AbstractOperatorSampler} <: AbstractLTFIM{O} end
 
-struct Rydberg{O,M <: UpperTriangular{Float64},UΩ <: AbstractVector{Float64}, Uδ <: AbstractVector{Float64}, L <: Lattice} <: AbstractRydberg{O}
+# struct Rydberg{O,M <: UpperTriangular{Float64},UΩ <: AbstractVector{Float64}, Uδ <: AbstractVector{Float64}, L <: Lattice} <: AbstractRydberg{O}
+#     op_sampler::O
+#     V::M
+#     Ω::UΩ
+#     δ::Uδ
+#     lattice::L
+#     energy_shift::Float64
+# end
+# nspins(H::Rydberg) = nspins(H.lattice)
+
+###################
+
+struct Rydberg{O,M <: Matrix{Float64},UΩ <: AbstractVector{Float64}, Uδ <: AbstractVector{Float64}, A} <: AbstractRydberg{O}
     op_sampler::O
     V::M
     Ω::UΩ
     δ::Uδ
-    lattice::L
+    atoms::A
     energy_shift::Float64
 end
-nspins(H::Rydberg) = nspins(H.lattice)
+
+nspins(H::Rydberg) = length(H.atoms)
 
 @inline diagonaloperator(::Type{<:AbstractRydberg}) = Diagonal([0, 1])
 @inline diagonaloperator(H::AbstractRydberg) = diagonaloperator(typeof(H))
 
 
-function make_prob_vector(H::Type{<:AbstractRydberg}, V::UpperTriangular{T}, Ω::AbstractVector{T}, δ::AbstractVector{T}; epsilon=0.0) where T
+function make_prob_vector(H::Type{<:AbstractRydberg}, V::Matrix{T}, Ω::AbstractVector{T}, δ::AbstractVector{T}; epsilon=0.0) where T
     @assert length(Ω) == length(δ) == size(V, 1) == size(V, 2)
     @assert (0.0 <= epsilon <= 1.0) "epsilon must be in the range [0, 1]!"
 
@@ -75,80 +88,82 @@ end
 # function BlockadeRydberg(dims::NTuple{N, Int}, J::Float64, hx::Float64, hz::Float64, pbc=true) where N
 # end
 
-function Rydberg(dims::NTuple{D, Int}, R_b, Ω, δ; pbc=true, trunc::Int=0, epsilon::Float64=0) where D
-    if D == 1
-        lat = Chain(dims[1], 1.0, pbc)
-    elseif D == 2
-        lat = Rectangle(dims[1], dims[2], 1.0, 1.0, pbc)
-    else
-        error("Unsupported number of dimensions. 1- and 2-dimensional lattices are supported.")
-    end
-    return Rydberg(lat, R_b, Ω, δ; trunc=trunc, epsilon=epsilon)
-end
+# function Rydberg(dims::NTuple{D, Int}, R_b, Ω, δ; pbc=true, trunc::Int=0, epsilon::Float64=0) where D
+#     if D == 1
+#         lat = Chain(dims[1], 1.0, pbc)
+#     elseif D == 2
+#         lat = Rectangle(dims[1], dims[2], 1.0, 1.0, pbc)
+#     else
+#         error("Unsupported number of dimensions. 1- and 2-dimensional lattices are supported.")
+#     end
+#     return Rydberg(lat, R_b, Ω, δ; trunc=trunc, epsilon=epsilon)
+# end
 
 
-function Rydberg(lat::Lattice, R_b::Float64, Ω::Float64, δ::Float64; trunc::Int=0, epsilon=0)
-    Ns = nspins(lat)
-    V = zeros(Float64, Ns, Ns)
+# function Rydberg(lat::Lattice, R_b::Float64, Ω::Float64, δ::Float64; trunc::Int=0, epsilon=0)
+#     Ns = nspins(lat)
+#     V = zeros(Float64, Ns, Ns)
 
-    if trunc > 0
-        _dist = sort!(collect(Set(lat.distance_matrix)))
-        uniq_dist = Vector{Float64}(undef, 0)
-        for i in eachindex(_dist)
-            if length(uniq_dist) == 0
-                push!(uniq_dist, _dist[i])
-            elseif !(last(uniq_dist) ≈ _dist[i])
-                push!(uniq_dist, _dist[i])
-            end
-        end
-        smallest_k = sort!(uniq_dist)[1:(trunc+1)]
-        dist = copy(lat.distance_matrix)
-        for i in eachindex(dist)
-            if dist[i] > last(smallest_k) && !(dist[i] ≈ last(smallest_k))
-                dist[i] = zero(dist[i])
-            end
-        end
-    elseif lat isa Rectangle && all(lat.PBC)
-        V = zeros(Ns, Ns)
-        K = 3  # figure out an efficient way to set this dynamically
+#     if trunc > 0
+#         _dist = sort!(collect(Set(lat.distance_matrix)))
+#         uniq_dist = Vector{Float64}(undef, 0)
+#         for i in eachindex(_dist)
+#             if length(uniq_dist) == 0
+#                 push!(uniq_dist, _dist[i])
+#             elseif !(last(uniq_dist) ≈ _dist[i])
+#                 push!(uniq_dist, _dist[i])
+#             end
+#         end
+#         smallest_k = sort!(uniq_dist)[1:(trunc+1)]
+#         dist = copy(lat.distance_matrix)
+#         for i in eachindex(dist)
+#             if dist[i] > last(smallest_k) && !(dist[i] ≈ last(smallest_k))
+#                 dist[i] = zero(dist[i])
+#             end
+#         end
+#     elseif lat isa Rectangle && all(lat.PBC)
+#         V = zeros(Ns, Ns)
+#         K = 3  # figure out an efficient way to set this dynamically
 
-        dist = zeros(Ns, Ns)
-        for v2 in -K:K, v1 in -K:K
-            dV = zeros(Ns, Ns)
-            for x2 in axes(dV, 2), x1 in axes(dV, 1)
-                i1, j1 = divrem(x1 - 1, lat.n1)
-                i2, j2 = divrem(x2 - 1, lat.n1)
-                r = [i2 - i1 + v1*lat.n1, j2 - j1 + v2*lat.n2]
-                dV[x1, x2] += Ω * (R_b/norm(r, 2))^6
-            end
-            # @show v2, v1, maximum(abs, dV)
+#         dist = zeros(Ns, Ns)
+#         for v2 in -K:K, v1 in -K:K
+#             dV = zeros(Ns, Ns)
+#             for x2 in axes(dV, 2), x1 in axes(dV, 1)
+#                 i1, j1 = divrem(x1 - 1, lat.n1)
+#                 i2, j2 = divrem(x2 - 1, lat.n1)
+#                 r = [i2 - i1 + v1*lat.n1, j2 - j1 + v2*lat.n2]
+#                 dV[x1, x2] += Ω * (R_b/norm(r, 2))^6
+#             end
+#             # @show v2, v1, maximum(abs, dV)
 
-            V += dV
-        end
+#             V += dV
+#         end
 
-        V = (V + V') / 2  # should already be symmetric but just in case
+#         V = (V + V') / 2  # should already be symmetric but just in case
 
-        return Rydberg(UpperTriangular(triu!(V, 1)), Ω*ones(Ns), δ*ones(Ns), lat; epsilon=epsilon)
-    else
-        dist = lat.distance_matrix
-    end
+#         return Rydberg(UpperTriangular(triu!(V, 1)), Ω*ones(Ns), δ*ones(Ns), lat; epsilon=epsilon)
+#     else
+#         dist = lat.distance_matrix
+#     end
 
-    @inbounds for i in 1:(Ns-1)
-        for j in (i+1):Ns
-            # a zero entry in distance_matrix means there should be no bond
-            V[i, j] = dist[i, j] != 0.0 ? Ω * (R_b / dist[i, j])^6 : 0.0
-        end
-    end
-    V = UpperTriangular(triu!(V, 1))
+#     @inbounds for i in 1:(Ns-1)
+#         for j in (i+1):Ns
+#             # a zero entry in distance_matrix means there should be no bond
+#             V[i, j] = dist[i, j] != 0.0 ? Ω * (R_b / dist[i, j])^6 : 0.0
+#         end
+#     end
+#     V = UpperTriangular(triu!(V, 1))
 
-    return Rydberg(V, Ω*ones(Ns), δ*ones(Ns), lat; epsilon=epsilon)
-end
+#     return Rydberg(V, Ω*ones(Ns), δ*ones(Ns), lat; epsilon=epsilon)
+# end
 
-function Rydberg(V::AbstractMatrix{T}, Ω::AbstractVector{T}, δ::AbstractVector{T}, lattice::Lattice; epsilon=zero(T)) where T
-    ops, p, energy_shift = make_prob_vector(AbstractRydberg, V, Ω, δ, epsilon=epsilon)
-    op_sampler = ImprovedOperatorSampler(AbstractLTFIM, ops, p)
-    return Rydberg{typeof(op_sampler), typeof(V), typeof(Ω), typeof(δ), typeof(lattice)}(op_sampler, V, Ω, δ, lattice, energy_shift)
-end
+# function Rydberg(V::AbstractMatrix{T}, Ω::AbstractVector{T}, δ::AbstractVector{T}, lattice::Lattice; epsilon=zero(T)) where T
+#     ops, p, energy_shift = make_prob_vector(AbstractRydberg, V, Ω, δ, epsilon=epsilon)
+#     op_sampler = ImprovedOperatorSampler(AbstractLTFIM, ops, p)
+#     return Rydberg{typeof(op_sampler), typeof(V), typeof(Ω), typeof(δ), typeof(lattice)}(op_sampler, V, Ω, δ, lattice, energy_shift)
+# end
 
 total_hx(H::Rydberg)::Float64 = sum(H.Ω) / 2
 haslongitudinalfield(H::AbstractRydberg) = !iszero(H.δ)
+
+

--- a/lib/BloqadeQMC/test/rydberg.jl
+++ b/lib/BloqadeQMC/test/rydberg.jl
@@ -1,15 +1,16 @@
-using Test, BloqadeQMC
+using Test
 using Statistics
 using Random
 using RandomNumbers
 using Measurements
 using Measurements: value, uncertainty
-using BinningAnalysis
-using BloqadeQMC: Chain, Square
 using BloqadeLattices: generate_sites, ChainLattice
+using BloqadeQMC: Chain, Square, rydberg_QMC
+using BloqadeQMC
 using BloqadeExpr: rydberg_h 
 using Yao: mat, ArrayReg
 using LinearAlgebra
+using BinningAnalysis
 
 # Generate ED values - do we want the ED to run every time? Or do we want to pre-calculate and store the values in a dict?
 
@@ -40,13 +41,6 @@ end
 # THRESHOLD_t = 2.576             threshold for t-test with ∞ DOF and 99.5% confidence   
 THRESHOLD_χ = 43.77             # threshold for χ² test with 30 DOF and p=0.05
 
-R_b = 7.74                      # This does correspond to C6 = 862690 * 2pi Mhz μm^6 at a Rabi frequency of Ω = 2π * 4.
-Ω = 2π * 4
-N = 9
-a = 5.48
-
-lat = Chain(N, a, false; trunc=Inf)
-
 @testset "1D Chain (9 atoms), β=0.005" begin
     β = 0.005
     EQ_MCS = 30
@@ -60,7 +54,8 @@ lat = Chain(N, a, false; trunc=Inf)
     χ_squared = 0
 
     for ii in 1:Δ_step
-        H = Rydberg(lat, R_b, Ω, Δ[ii])
+        @show ii
+        H = rydberg_QMC(atoms, Ω=Ω, Δ=Δ[ii])
         ts = BinaryThermalState(H, M)
         d = Diagnostics()
     
@@ -81,6 +76,7 @@ lat = Chain(N, a, false; trunc=Inf)
         append!(energy_QMC_β1, energy_binned)
 
         χ_squared += abs2(value(energy_QMC_β1[ii]) - energy_ED[1, ii]) / abs2(uncertainty(energy_QMC_β1[ii]))
+        @show χ_squared
         # @test abs(stdscore(energy_QMC_β1[ii], energy_ED[1,ii])) < THRESHOLD_t       t-test for testing each QMC run individually
     end
 
@@ -101,7 +97,8 @@ end
     χ_squared = 0
 
     for ii in 1:Δ_step
-        H = Rydberg(lat, R_b, Ω, Δ[ii])
+        @show ii
+        H = rydberg_QMC(atoms, Ω=Ω, Δ=Δ[ii])
         ts = BinaryThermalState(H, M)
         d = Diagnostics()
     
@@ -123,7 +120,7 @@ end
         println()
         #append!(energy_QMC_β2, mean_and_stderr(x -> -x/β, ns) + H.energy_shift)
 
-        χ_squared += abs2(value(energy_QMC_β2[ii]) - energy_ED[2, ii]) / abs2(uncertainty(energy_QMC_β2[ii]))
+        @show χ_squared += abs2(value(energy_QMC_β2[ii]) - energy_ED[2, ii]) / abs2(uncertainty(energy_QMC_β2[ii]))
         # @test abs(stdscore(energy_QMC_β2[ii], energy_ED[2,ii])) < THRESHOLD_t
     end
     @test χ_squared < THRESHOLD_χ
@@ -135,14 +132,15 @@ end
     MCS = 10_000
     M = 5000
 
-    rng = MersenneTwister(12345)
+    rng = MersenneTwister(1234)
 
     energy_QMC_β3 = []
 
     χ_squared = 0
 
     for ii in 1:Δ_step
-        H = Rydberg(lat, R_b, Ω, Δ[ii])
+        @show ii
+        H = rydberg_QMC(atoms, Ω=Ω, Δ=Δ[ii])
         ts = BinaryThermalState(H, M)
         d = Diagnostics()
     
@@ -158,13 +156,14 @@ end
         energy(x) = -x / β + H.energy_shift
         BE = LogBinner(energy.(ns))
         τ_energy = tau(BE)
+        @show τ_energy
         ratio = 2 * τ_energy + 1
-        energy_binned = measurement(mean(BE), std_error(BE)*sqrt(ratio)) 
+        @show energy_binned = measurement(mean(BE), std_error(BE)*sqrt(ratio)) 
         append!(energy_QMC_β3, energy_binned)
         println()
         #append!(energy_QMC_β3, mean_and_stderr(x -> -x/β, ns) + H.energy_shift)
 
-        χ_squared += abs2(value(energy_QMC_β3[ii]) - energy_ED[3, ii]) / abs2(uncertainty(energy_QMC_β3[ii]))
+        @show χ_squared += abs2(value(energy_QMC_β3[ii]) - energy_ED[3, ii]) / abs2(uncertainty(energy_QMC_β3[ii]))
         # @test abs(stdscore(energy_QMC_β3[ii], energy_ED[2,ii])) < THRESHOLD_t
     end
     @test χ_squared < THRESHOLD_χ


### PR DESCRIPTION
Current changes:
- modified Rydberg struct within the QMC to use BloqadeLattices instead of QMC lattices
- swapped out long Rydberg() function that constructs the interaction matrix within the QMC for Phil's rydberg_interaction_matrix
- wrote new interface function rydberg_QMC() that is supposed to mimic rydberg_h() but constructs the Rydberg struct needed for the QMC (instead of a vanilla Rydberg Hamiltonian) 