### PR TITLE
Fix `submit_to_braket` function signature and updated docstrings

### DIFF
--- a/lib/BloqadeSchema/src/submit_to_braket.jl
+++ b/lib/BloqadeSchema/src/submit_to_braket.jl
@@ -19,7 +19,7 @@ Credentials can be passed in explicitly through an `AWS.AWSCredentials` struct o
 - `region="us-east-1"`: AWS Region machine is located in
 - `credentials::Union{AWSCredentials, Nothing}=nothing`: `AWS.AWSCredentials` instance you can create to login.
 """
-function submit_to_braket(h::BloqadeExpr.Hamiltonian, 
+function submit_to_braket(h::BloqadeExpr.RydbergHamiltonian, 
                           n_shots::Int, 
                           device_capabilities = BloqadeSchema.get_device_capabilities();
                             arn="arn:aws:braket:us-east-1::device/qpu/quera/Aquila",
@@ -49,7 +49,7 @@ Credentials can be passed in explicitly through an `AWS.AWSCredentials` struct o
 - `region="us-east-1"`: AWS Region machine is located in
 - `credentials::Union{AWSCredentials, Nothing}=nothing`: `AWS.AWSCredentials` instance you can create to login.
 """
-function submit_to_braket(h::BloqadeExpr.Hamiltonian,
+function submit_to_braket(h::BloqadeExpr.RydbergHamiltonian,
                           translation_params::BloqadeSchema.SchemaTranslationParams;
                             arn="arn:aws:braket:us-east-1::device/qpu/quera/Aquila",
                             region="us-east-1",

--- a/lib/BloqadeSchema/src/submit_to_braket.jl
+++ b/lib/BloqadeSchema/src/submit_to_braket.jl
@@ -1,7 +1,7 @@
 """
     submit_to_braket(h::BloqadeExpr.Hamiltonian, n_shots::Int; <keyword arguments>)
 
-Submits a `BloqadeExpr.Hamiltonian` instance to Braket with `n_shots` defining the number of times
+Submits a `BloqadeExpr.RydbergHamiltonian` instance to Braket with `n_shots` defining the number of times
 the Hamiltonian should be executed. 
 
 
@@ -35,9 +35,9 @@ function submit_to_braket(h::BloqadeExpr.RydbergHamiltonian,
 end
 
 """
-    submit_to_braket(h::BloqadeExpr.Hamiltonian, translation_params::BloqadeSchema.SchemaTranslationParams; <keyword arguments>)
+    submit_to_braket(h::BloqadeExpr.RydbergHamiltonian, translation_params::BloqadeSchema.SchemaTranslationParams; <keyword arguments>)
 
-Submits a `BloqadeExpr.Hamiltonian` instance to Braket with `BloqadeSchema.SchemaTranslationParams` containing the number of shots and 
+Submits a `BloqadeExpr.RydbergHamiltonian` instance to Braket with `BloqadeSchema.SchemaTranslationParams` containing the number of shots and 
 device capabilities, returning an `AWS.AwsQuantumTask` and `Bloqade.HardwareTransformInfo` upon
 converting the Hamiltonian to one the hardware can execute.
 

--- a/lib/BloqadeSchema/src/submit_to_braket.jl
+++ b/lib/BloqadeSchema/src/submit_to_braket.jl
@@ -4,13 +4,6 @@
 Submits a `BloqadeExpr.RydbergHamiltonian` instance to Braket with `n_shots` defining the number of times
 the Hamiltonian should be executed. 
 
-
-
-# Keyword Arguments
-- `arn="arn:aws:braket:us-east-1::device/qpu/quera/Aquila"`: ARN for the machine
-- `region="us-east-1"`: AWS Region machine is located in
-- `credentials::Union{AWSCredentials, Nothing}=nothing`: `AWS.AWSCredentials` instance you can create to login.
-
 Credentials can be passed in explicitly through an `AWS.AWSCredentials` struct or by passing in 
 `nothing`, in which case credentials will be sought in the standard AWS locations.
 
@@ -18,6 +11,13 @@ Credentials can be passed in explicitly through an `AWS.AWSCredentials` struct o
 - `arn="arn:aws:braket:us-east-1::device/qpu/quera/Aquila"`: ARN for the machine
 - `region="us-east-1"`: AWS Region machine is located in
 - `credentials::Union{AWSCredentials, Nothing}=nothing`: `AWS.AWSCredentials` instance you can create to login.
+
+# Logs/Warnings/Exceptions
+
+An `AWS.NoCredentials` exception is thrown containing a `message` string "Can't find AWS credentials!" if the credentials given are invalid.
+
+[`BloqadeSchema.hardware_transform`](@ref) is always invoked, meaning its debug logs are also always emitted containing the difference (error)
+between the original waveforms in `h` and the newly generated ones compatible with hardware as well as the same transformation for atom positions.
 """
 function submit_to_braket(h::BloqadeExpr.RydbergHamiltonian, 
                           n_shots::Int, 
@@ -38,8 +38,7 @@ end
     submit_to_braket(h::BloqadeExpr.RydbergHamiltonian, translation_params::BloqadeSchema.SchemaTranslationParams; <keyword arguments>)
 
 Submits a `BloqadeExpr.RydbergHamiltonian` instance to Braket with `BloqadeSchema.SchemaTranslationParams` containing the number of shots and 
-device capabilities, returning an `AWS.AwsQuantumTask` and `Bloqade.HardwareTransformInfo` upon
-converting the Hamiltonian to one the hardware can execute.
+device capabilities. Returns an `AWS.AwsQuantumTask` upon converting the Hamiltonian to one the hardware can execute and submitting it.
 
 Credentials can be passed in explicitly through an `AWS.AWSCredentials` struct or by passing in 
 `nothing`, in which case credentials will be sought in the standard AWS locations.
@@ -48,6 +47,13 @@ Credentials can be passed in explicitly through an `AWS.AWSCredentials` struct o
 - `arn="arn:aws:braket:us-east-1::device/qpu/quera/Aquila"`: ARN for the machine
 - `region="us-east-1"`: AWS Region machine is located in
 - `credentials::Union{AWSCredentials, Nothing}=nothing`: `AWS.AWSCredentials` instance you can create to login.
+
+# Logs/Warnings/Exceptions
+
+An `AWS.NoCredentials` exception is thrown containing a `message` string "Can't find AWS credentials!" if the credentials given are invalid.
+
+[`hardware_transform`](@ref) is always invoked internally, meaning its debug logs are also always emitted containing the difference (error)
+between the original waveforms in `h` and the newly generated ones compatible with hardware as well as the same transformation for atom positions.
 """
 function submit_to_braket(h::BloqadeExpr.RydbergHamiltonian,
                           translation_params::BloqadeSchema.SchemaTranslationParams;
@@ -56,7 +62,8 @@ function submit_to_braket(h::BloqadeExpr.RydbergHamiltonian,
                             credentials::Union{AWSCredentials, Nothing}=nothing
                         )
 
-    h_transformed, transform_info = hardware_transform(h)
+    # Transform error info is output via @debug
+    h_transformed, _ = hardware_transform(h)
     bloqade_ir = BloqadeSchema.to_schema(h_transformed, translation_params)
     task = submit_to_braket(bloqade_ir; arn=arn, region=region, credentials=credentials)
     return task, transform_info
@@ -74,6 +81,10 @@ Credentials can be passed in explicitly through an `AWS.AWSCredentials` struct o
 - `arn="arn:aws:braket:us-east-1::device/qpu/quera/Aquila"`: ARN for the machine
 - `region="us-east-1"`: AWS Region machine is located in
 - `credentials::Union{AWSCredentials, Nothing}=nothing`: `AWS.AWSCredentials` instance you can create to login.
+
+# Logs/Warnings/Exceptions
+
+An `AWS.NoCredentials` exception is thrown containing a `message` string "Can't find AWS credentials!" if the credentials given are invalid.
 """
 function submit_to_braket(ts::BloqadeSchema.TaskSpecification; 
         arn="arn:aws:braket:us-east-1::device/qpu/quera/Aquila", 


### PR DESCRIPTION
* `submit_to_braket` function signatures have been updated to proper ones (should accept `RydbergHamiltonian` versus just `Hamiltonian`) from `BloqadeSchema`.
* Docstrings for `submit_to_braket` now explicitly state debug logs are emitted along with exceptions for invalid credentials from `AWS.jl`