### PR TITLE
Make atom transform intervention more explicit

### DIFF
--- a/docs/src/schema.md
+++ b/docs/src/schema.md
@@ -20,6 +20,9 @@ h = rydberg_h(atoms; Δ = Δ, Ω = Ω, ϕ = ϕ)
 
 To transform the Hamiltonian into something the hardware is capable of supporting, we can pass it through [`hardware_transform`](@ref).
 
+!!! warning "Limitations on Atom Position Transformations"
+    While `hardware_transform` may attempt to adjust atom positions so that they conform to hardware position resolution capabilities, the function will NOT move atoms such that they satisfy minimum spacing constraints. The `validate` function presented later will explicitly indicate which atoms are in violation of the position constraints but will require the user to make the necessary changes.
+
 `hardware_transform` accepts information from [`get_device_capabilities`](@ref) (already called as a default argument) which provides information on the machine's capabilities and returns the transformed hamiltonian along with additional information regarding the difference (error) between the originally defined lattice geometry and waveforms versus their transformed versions through a [`HardwareTransformInfo`](@ref) instance.
 
 

--- a/lib/BloqadeSchema/src/transform.jl
+++ b/lib/BloqadeSchema/src/transform.jl
@@ -548,6 +548,11 @@ machine is capable of executing as well as:
 * The 1-norm of the difference between the original and transformed waveforms
 which are all stored in a [`HardwareTransformInfo`](@ref) struct.
 
+Note that not all atom position constraints are accounted for, such as the maximum lattice width, lattice height, 
+and minimum supported spacings. Only position resolution is automatically accounted for.
+This may result in the [`validation`](@ref) function failing and requiring user intervention to modify the atom 
+positions such that they satisfy the other constraints.
+
 # Logs/Warnings/Exceptions
 
 Debug logs are *always* emitted containing the error (defined as the 1-norm of the difference between


### PR DESCRIPTION
Suggested by @plquera 🎉 

Currently `hardware_transform` does not automatically move atoms to satisfy all hardware spacial constraints, only doing so to satisfy position resolution. While this is documented, it would definitely improve the UX to have this behavior made more explicit.

I've gone ahead and done this by adding an admonition and updating the docstring for `hardware_transform` (`hardware_transform_atoms` already states this behavior). 