### PR TITLE
Add Flag to Turn off Validation for submit_to_braket

### DIFF
--- a/lib/BloqadeSchema/src/submit_to_braket.jl
+++ b/lib/BloqadeSchema/src/submit_to_braket.jl
@@ -67,11 +67,14 @@ function submit_to_braket(h::BloqadeExpr.RydbergHamiltonian,
 
     # Transform error info is output via @debug
     h_transformed, _ = hardware_transform(h)
-    # bloqade_ir = BloqadeSchema.to_schema(h_transformed, translation_params)
     bloqade_ir = if validate_h 
         BloqadeSchema.to_schema(h_transformed, translation_params)
     else
-        BloqadeSchema.to_schema_no_validation(schema_parse_rydberg_fields(h_transformed)..., translation_params)
+        atoms, ϕ, Ω, Δ, δ, Δi = schema_parse_rydberg_fields(h_transformed)
+        # not needed, no local detuning going on
+        # δ already set to nothing
+        Δi = nothing
+        BloqadeSchema.to_schema_no_validation(atoms, ϕ, Ω, Δ, δ, Δi, translation_params)
     end
     task = submit_to_braket(bloqade_ir; arn=arn, region=region, credentials=credentials)
     return task

--- a/lib/BloqadeSchema/src/submit_to_braket.jl
+++ b/lib/BloqadeSchema/src/submit_to_braket.jl
@@ -71,7 +71,7 @@ function submit_to_braket(h::BloqadeExpr.RydbergHamiltonian,
     bloqade_ir = if validate_h 
         BloqadeSchema.to_schema(h_transformed, translation_params)
     else
-        BloqadeSchema.to_schema_no_validation(schema_parse_rydberg_fields(h)..., translation_params)
+        BloqadeSchema.to_schema_no_validation(schema_parse_rydberg_fields(h_transformed)..., translation_params)
     end
     task = submit_to_braket(bloqade_ir; arn=arn, region=region, credentials=credentials)
     return task

--- a/lib/BloqadeSchema/src/submit_to_braket.jl
+++ b/lib/BloqadeSchema/src/submit_to_braket.jl
@@ -8,10 +8,10 @@ Credentials can be passed in explicitly through an `AWS.AWSCredentials` struct o
 `nothing`, in which case credentials will be sought in the standard AWS locations.
 
 # Keyword Arguments
+- `validate_h=true` =  Validates the Hamiltonian to ensure compatibility with the machine.
 - `arn="arn:aws:braket:us-east-1::device/qpu/quera/Aquila"`: ARN for the machine
 - `region="us-east-1"`: AWS Region machine is located in
 - `credentials::Union{AWSCredentials, Nothing}=nothing`: `AWS.AWSCredentials` instance you can create to login.
-- `validate_h=true` =  Validates the Hamiltonian to ensure compatibility with the machine.
 
 # Logs/Warnings/Exceptions
 
@@ -23,7 +23,7 @@ between the original waveforms in `h` and the newly generated ones compatible wi
 function submit_to_braket(h::BloqadeExpr.RydbergHamiltonian, 
                           n_shots::Int, 
                           device_capabilities = BloqadeSchema.get_device_capabilities();
-                            validate_h = true,
+                            validate_h=true,
                             arn="arn:aws:braket:us-east-1::device/qpu/quera/Aquila",
                             region="us-east-1",
                             credentials::Union{AWSCredentials, Nothing}=nothing
@@ -33,7 +33,7 @@ function submit_to_braket(h::BloqadeExpr.RydbergHamiltonian,
         n_shots,
         device_capabilities
     )
-    return submit_to_braket(h, translation_params, validate_h; arn=arn, region=region, credentials=credentials)
+    return submit_to_braket(h, translation_params; validate_h, arn=arn, region=region, credentials=credentials)
 end
 
 """
@@ -46,10 +46,10 @@ Credentials can be passed in explicitly through an `AWS.AWSCredentials` struct o
 `nothing`, in which case credentials will be sought in the standard AWS locations.
 
 # Keyword Arguments
+- `validate_h=true` =  Validates the Hamiltonian to ensure compatibility with the machine.
 - `arn="arn:aws:braket:us-east-1::device/qpu/quera/Aquila"`: ARN for the machine
 - `region="us-east-1"`: AWS Region machine is located in
 - `credentials::Union{AWSCredentials, Nothing}=nothing`: `AWS.AWSCredentials` instance you can create to login.
-- `validate_h=true` =  Validates the Hamiltonian to ensure compatibility with the machine.
 # Logs/Warnings/Exceptions
 
 An `AWS.NoCredentials` exception is thrown containing a `message` string "Can't find AWS credentials!" if the credentials given are invalid.
@@ -71,7 +71,7 @@ function submit_to_braket(h::BloqadeExpr.RydbergHamiltonian,
     bloqade_ir = if validate_h 
         BloqadeSchema.to_schema(h_transformed, translation_params)
     else
-        BloqadeSchema.to_schema_no_validation(schema_parse_rydberg_fields(h)...)
+        BloqadeSchema.to_schema_no_validation(schema_parse_rydberg_fields(h)..., translation_params)
     end
     task = submit_to_braket(bloqade_ir; arn=arn, region=region, credentials=credentials)
     return task


### PR DESCRIPTION
Requested by @kshyatt 🤠 

Currently `submit_to_braket` defaults to using the `to_schema` function which validates all Hamiltonians given to it at a (potentially steep) time penalty.

A flag has been added to turn this validation off and just generate the task using `to_schema_no_validation` (flag defaults to `true`)