### PR TITLE
Clearer docs + error message on transforming hamiltonian with missing waveforms

### DIFF
--- a/docs/src/schema.md
+++ b/docs/src/schema.md
@@ -20,8 +20,10 @@ h = rydberg_h(atoms; Δ = Δ, Ω = Ω, ϕ = ϕ)
 
 To transform the Hamiltonian into something the hardware is capable of supporting, we can pass it through [`hardware_transform`](@ref).
 
-!!! warning "Limitations on Atom Position Transformations"
+!!! warning "Limitations on Transformations"
     While `hardware_transform` may attempt to adjust atom positions so that they conform to hardware position resolution capabilities, the function will NOT move atoms such that they satisfy minimum spacing constraints. The `validate` function presented later will explicitly indicate which atoms are in violation of the position constraints but will require the user to make the necessary changes.
+
+    Furthermore, `hardware_transform` requires that all waveforms the Hamiltonian could use (Rabi frequency, detuning, and phase) are explicitly specified even if they are not used. To indicate non-use of a waveform, [`BloqadeWaveforms.constant`](@ref) should be used with the value set to zero.
 
 `hardware_transform` accepts information from [`get_device_capabilities`](@ref) (already called as a default argument) which provides information on the machine's capabilities and returns the transformed hamiltonian along with additional information regarding the difference (error) between the originally defined lattice geometry and waveforms versus their transformed versions through a [`HardwareTransformInfo`](@ref) instance.
 

--- a/lib/BloqadeSchema/src/transform.jl
+++ b/lib/BloqadeSchema/src/transform.jl
@@ -48,7 +48,10 @@ function check_waveform(field,name)
         return
 
     end
-    (isnothing(field) || field isa Number || BloqadeExpr.is_time_function(field)) && error("Failed to transform $name to hardware, $name must be a Waveform.\n If $name is constant or zero use `BloqadeWaveforms.constant`.")
+    # enforce requirement that ALL waveforms must be present prior to invoking hardware_transform (Bloqade doesn't assume any default values).
+    # Transform fails otherwise!
+    isnothing(field) && error("$name must be specified prior to transform to hardware compatible format.\n You can specify the absence of a waveform by passing in a constant waveform (use `BloqadeWaveforms.constant`) with value set to zero.")
+    (field isa Number || BloqadeExpr.is_time_function(field)) && error("Failed to transform $name to hardware, $name must be a Waveform.\n If $name is constant or zero use `BloqadeWaveforms.constant`.")
 
 end
 # warns user if the duration of the waveform will be rounded by the time resolution.

--- a/lib/BloqadeSchema/src/transform.jl
+++ b/lib/BloqadeSchema/src/transform.jl
@@ -555,7 +555,7 @@ machine is capable of executing as well as:
 which are all stored in a [`HardwareTransformInfo`](@ref) struct.
 
 `hardware_transform` expects that ALL waveforms `h` can have specified (Ω, Δ, ϕ) are explicitly defined.
-If there is a waveform that is not being used, a [`BloqadeWaveforms.constant`] waveform should be created with value zero
+If there is a waveform that is not being used, a [`BloqadeWaveforms.constant`](@ref) waveform should be created with value zero
 to indicate non-use.
 
 Note that not all atom position constraints are accounted for, such as the maximum lattice width, lattice height, 

--- a/lib/BloqadeSchema/src/transform.jl
+++ b/lib/BloqadeSchema/src/transform.jl
@@ -283,6 +283,7 @@ the shorter waveform is padded with zeros for values to make the durations equal
 
 Exceptions are thrown if Ω is:
 - Not of type [`BloqadWaveforms.Waveform`](@ref)
+- Not present (`nothing` was passed in)
 - Not a global drive (e.g.: Vector of Waveforms, localized Ω is not supported)
 - the maximum slope allowed for the waveform from `device_capabilities` is set to infinity 
 - the minimum time step allowed for the waveform from `device_capabilities` is set to zero
@@ -348,6 +349,7 @@ the shorter waveform is padded with zeros for values to make the durations equal
 
 Exceptions are thrown if ϕ is:
 - Not of type [`BloqadWaveforms.Waveform`](@ref)
+- Not present (`nothing` was passed in)
 - Not a global drive (e.g.: Vector of Waveforms, localized ϕ is not supported)
 - the maximum slope allowed for the waveform from `device_capabilities` is set to infinity 
 - the minimum time step allowed for the waveform from `device_capabilities` is set to zero
@@ -417,6 +419,7 @@ the shorter waveform is padded with zeros for values to make the durations equal
 
 Exceptions are thrown if Δ is:
 - Not of type [`BloqadWaveforms.Waveform`](@ref)
+- Not present (`nothing` was passed in)
 - Not a global drive (e.g. Vector of Waveforms, localized Δ is not supported)
 - the maximum slope allowed for the waveform from `device_capabilities` is set to infinity 
 - the minimum time step allowed for the waveform from `device_capabilities` is set to zero
@@ -550,6 +553,10 @@ machine is capable of executing as well as:
 * The mean squared error between original positions of the atoms and the transformed ones
 * The 1-norm of the difference between the original and transformed waveforms
 which are all stored in a [`HardwareTransformInfo`](@ref) struct.
+
+`hardware_transform` expects that ALL waveforms `h` can have specified (Ω, Δ, ϕ) are explicitly defined.
+If there is a waveform that is not being used, a [`BloqadeWaveforms.constant`] waveform should be created with value zero
+to indicate non-use.
 
 Note that not all atom position constraints are accounted for, such as the maximum lattice width, lattice height, 
 and minimum supported spacings. Only position resolution is automatically accounted for.


### PR DESCRIPTION
Implements the features requested in #513 for clearer documentation and more explicit errors on `hardware_transform` requiring all waveforms that the Hamiltonian can use be explicitly specified ahead of time.