### PR TITLE
Updated GPU Acceleration documentation with temporary fix for CUDA.jl

### DIFF
--- a/docs/src/cuda.md
+++ b/docs/src/cuda.md
@@ -1,14 +1,18 @@
 # [GPU Acceleration] (@id cuda)
 
+!!! danger "CUDA.jl Version 3 Required"
+
+    Bloqade currently does not work with the latest version (4.x) of the [CUDA](https://github.com/JuliaGPU) package. As a workaround you will need to install version 3. The installation instructions below should already address this.
+
 Bloqade supports CUDA acceleration. To use
 CUDA acceleration, you will need a NVIDIA graphics processing unit (GPU).
 
 ## Installation
 
-To use CUDA accelerators, you need to install the CUDA package and the Adapt package:
+To use CUDA accelerators, you need to install the [CUDA](https://github.com/JuliaGPU/CUDA.jl) package and the [Adapt](https://github.com/JuliaGPU/Adapt.jl) package:
 
 ```julia
-pkg> add CUDA Adapt
+pkg> add CUDA@3 Adapt
 ```
 
 This will automatically download all the needed dependencies of
@@ -22,7 +26,7 @@ julia> CUDA.version()
 ## Using CUDA
 
 Converting your CPU-based simulation to CUDA-based simulation
-is extremely simple: just use the `cu` function from `CUDA`
+is extremely simple: just use the `adapt` function from `Adapt`
 on the register object, which will convert the CPU-based
 register to a CUDA-based register, e.g.:
 
@@ -32,7 +36,7 @@ reg = zero_state(5)
 dreg = adapt(CuArray, reg) # device register
 ```
 
-For emulation, you can call `cu` on your emulation object
+For emulation, you can call `adapt` on your emulation object
 to convert everything (emulation intermediate memory, etc.)
 into the GPU memory, e.g.:
 
@@ -40,5 +44,18 @@ into the GPU memory, e.g.:
 adapt(CuArray, KrylovEvolution(reg, clocks, h))
 ```
 
-Other codes in Bloqade should work with CUDA
+To perform operations after emulation (such as calculating the rydberg density) 
+you will need to move the object out of GPU memory. This can be done so via `adapt` again:
+
+```julia
+# get the problem onto the GPU and perform emulation there:
+gpu_prob = adapt(CuArray, SchrodingerProblem(register, time_span, hamiltonian))
+integrator = init(gpu_prob, Vern9())
+emulate!(integrator)
+
+# get the problem off the GPU for subsequent processing/analysis:
+prob = adapt(Array, gpu_prob)
+```
+
+Other code written with Bloqade should work with CUDA
 automatically.


### PR DESCRIPTION
The latest version of CUDA.jl doesn't work because of [regression bug](https://github.com/JuliaGPU/CUDA.jl/issues/1760) identified by @Roger-luo . The Bloqade GPU documentation has been updated with instructions for a temporary fix and slightly edited/expanded to make it easier to understand.