### PR TITLE
Set default ODE solver to DP8 and add admonition to emulation.md

### DIFF
--- a/docs/src/emulation.md
+++ b/docs/src/emulation.md
@@ -114,10 +114,9 @@ However, if one expects to retrieve the results during the time evolution, e.g.,
 plotting Rydberg densities with the evolution time, fixed-step methods are sometimes 
 preferred.
 
-More specifically, when the adaptive steps are turned on, the time steps might be large,
-but if one is interested in measuring some observables in smaller time steps, then the adaptive step 
-method will not produce accurate results for the finer time step, but instead output results at the specific adaptive steps. 
-In this situation, it's better to use fixed-step methods at the clocks where the observables are measured.
+More specifically, when the adaptive steps are turned on the time steps can become large.
+However, if one is interested in measuring some observables in smaller time steps, then the adaptive step method will not produce accurate results for the finer time step, instead outputting results at the specific adaptive steps. 
+In this situation, it's better to use fixed-step methods at the times where the observables are measured.
 
 One can use the code below to turn off the adaptive steps when setting up the [`SchrodingerProblem`](@ref):
 
@@ -129,9 +128,7 @@ prob = SchrodingerProblem(reg, 3.0, h, adaptive = false, dt=1e-3);
 ```
 
 Here, we've specified the fixed time step as `dt = 1e-3`.
-If one only expects the final state of the evolution,
-or the intervals between each chosen clock is much larger than the maximum
-step size, then adaptive steps are preferred.
+If one only wants the final state of the evolution or if the intervals between each chosen time are much larger than the maximum step size, then adaptive steps are preferred.
 
 ### Define the Krylov Emulation Problem
 

--- a/docs/src/emulation.md
+++ b/docs/src/emulation.md
@@ -132,7 +132,7 @@ If one only wants the final state of the evolution or if the intervals between e
 
 ### Define the Krylov Emulation Problem
 
-The Krylov-based method expects time-independent Hamiltonians. One can define such a time evolution via [`KrylovEvolution`](@ref) object.
+The Krylov-based method expects time-independent Hamiltonians. One can define such a time evolution via a [`KrylovEvolution`](@ref) object.
 
 ```@docs
 KrylovEvolution
@@ -146,7 +146,7 @@ We can run the Krylov-based emulation in a similar way using [`emulate!`](@ref):
 emulate!(KrylovEvolution(reg, clocks, h))
 ```
 
-However, as its name suggests, the Krylov-based emulation is not a standard ODE problem that DiffEq  supports. Thus, it does not support the ODE problem interface, but it's more like a gate-based interface. For example, the object `KrylovEvolution` is iterable:
+However, as its name suggests, the Krylov-based emulation is not a standard ODE problem that DiffEq  supports. Thus, it does not support the ODE problem interface, but is more like a gate-based interface. For example, the object `KrylovEvolution` is iterable:
 
 ```@example evolution
 for (step, reg, duration) in KrylovEvolution(reg, clocks, h)

--- a/lib/BloqadeODE/src/problem.jl
+++ b/lib/BloqadeODE/src/problem.jl
@@ -76,7 +76,7 @@ struct SchrodingerProblem{Reg,EquationType<:ODEFunction,uType,tType,Algo,Kwargs}
     p::Nothing # well make DiffEq happy
 end
 
-function SchrodingerProblem(reg::AbstractRegister, tspan, expr; algo=AutoVern9(Rodas5(autodiff=false)), kw...)
+function SchrodingerProblem(reg::AbstractRegister, tspan, expr; algo=DP8(), kw...)
     nqudits(reg) == nqudits(expr) || throw(ArgumentError("number of qubits/sites does not match!"))
     # remove this after ArrayReg start using AbstractVector
     state = statevec(reg)


### PR DESCRIPTION
Per @weinbe58 's request, the default ODE solver for all `SchrodingerProblem` instances is now Dormand-Prince. A tip has been added in the documentation to alert users of this behavior with the `AutoVern9(Rodas5)` being recommended should stiffness in the equation be expected.

Furthermore, the general wording has been modified in certain paragraphs to be more grammatically correct. 