### PR TITLE
Added deleteat! function to delete atoms at certain indices

### DIFF
--- a/docs/src/lattices.md
+++ b/docs/src/lattices.md
@@ -120,9 +120,9 @@ Bloqade.plot(generate_sites(kagome, 5, 5); vectors=unitvectors(kagome), bond_lin
 ```
 
 
-## Sort Sites and Other Operations on Lattices
+## Sorting Sites and Other Operations on Lattices
 
-We also support different operations on the generated lattices. For instance,  one can apply some predefined filters, e.g. [`rescale_axes`](@ref), [`clip_axes`](@ref), [`offset_axes`](@ref), to manipulate atom locations:
+We also support different operations on the generated lattices. For instance, one can apply some predefined filters, e.g. [`rescale_axes`](@ref), [`clip_axes`](@ref), [`offset_axes`](@ref), to manipulate atom locations:
 
 ```@example quick-start
 atoms = generate_sites(HoneycombLattice(), 3, 5; scale = 4.5)
@@ -153,7 +153,15 @@ Then one can get the sorted atoms by typing:
 sorted_atoms = collect_atoms(atoms_in_grid)
 ```
 
-Note that the sorting has changed the index numbering of the atoms. 
+Note that the sorting will change the index numbering of the atoms. 
+
+You can also delete atoms given their index number:
+```@example quick-start
+deleteat!(atoms, 8, 9, 13, 14, 18, 20, 23)
+atoms
+```
+
+Note that this permanently changes the contents of `atoms` and just like sorting atoms, will change the index numbering albeit to preserve the integer sequence without gaps.
 
 
 

--- a/lib/BloqadeLattices/src/BloqadeLattices.jl
+++ b/lib/BloqadeLattices/src/BloqadeLattices.jl
@@ -8,6 +8,7 @@ using LuxorGraphPlot
 using LuxorGraphPlot: Point
 using LuxorGraphPlot.Luxor: Colors
 using LinearAlgebra
+import Base.deleteat!
 
 export # types
     AbstractLattice,
@@ -21,6 +22,7 @@ export # types
     RectangularLattice,
     # interfaces
     generate_sites,
+    deleteat!,
     offset_axes,
     random_dropout,
     rescale_axes,

--- a/lib/BloqadeLattices/src/lattice.jl
+++ b/lib/BloqadeLattices/src/lattice.jl
@@ -537,6 +537,33 @@ function collect_atoms(mg::MaskedGrid)
     return AtomList(map(ci -> (mg.xs[ci.I[1]], mg.ys[ci.I[2]]), findall(mg.mask)))
 end
 
+"""
+    deleteat!(sites::AtomList, indices...)
+
+Deletes an atom from `sites` via its index/indices.
+
+When `sites` is displayed after deletion the atoms will be renumbered to maintain a proper integer sequence, e.g.
+given a sequence of atoms numbered "1,2,3,4", if atom 3 is deleted then the new ordering will be "1,2,3".
+
+```jldoctest; setup=:(using BloqadeLattices)
+julia> sites = generate_sites(SquareLattice(), 2, 2, scale=6.7)
+4-element AtomList{2, Float64}:
+ (0.0, 0.0)
+ (6.7, 0.0)
+ (0.0, 6.7)
+ (6.7, 6.7)
+
+julia> deleteat!(sites, 2, 3)
+2-element AtomList{2, Float64}:
+ (0.0, 0.0)
+ (6.7, 6.7)
+```
+
+"""
+function deleteat!(sites::AtomList, indices...)
+    deleteat!(sites.atoms, sort(collect(indices)))
+end
+
 # TODO
 # pseudo-lattices,
 # image/svg output (maybe),

--- a/lib/BloqadeLattices/test/lattice.jl
+++ b/lib/BloqadeLattices/test/lattice.jl
@@ -52,6 +52,15 @@ end
     sites = AtomList([(0.2, 0.3), (0.4, 0.8)])
     @test (sites |> rescale_axes(2.0)) == [(0.4, 0.6), (0.8, 1.6)]
 
+    # delete atom positions
+    sites = generate_sites(SquareLattice(), 5, 5, scale=3)
+    deleteat!(sites, 1)
+    @test length(sites) == 24
+    deleteat!(sites, 12, 10, 11)
+    @test length(sites) == 21
+    deleteat!(sites, 1, 20)
+    @test length(sites) == 19
+
 end
 
 @testset "fix site ordering" begin


### PR DESCRIPTION
Requested by @plquera, this defines `deleteat!` on the `AtomList` type to make it easier to delete atoms given their indexing number.