### PR TITLE
Toggle Unicode

### DIFF
--- a/lib/BloqadeLattices/src/BloqadeLattices.jl
+++ b/lib/BloqadeLattices/src/BloqadeLattices.jl
@@ -10,6 +10,8 @@ using LuxorGraphPlot.Luxor: Colors
 using LinearAlgebra
 import Base.deleteat!
 
+UNICODE_ENABLED = Ref(true)
+
 export # types
     AbstractLattice,
     HoneycombLattice,

--- a/lib/BloqadeLattices/src/visualize.jl
+++ b/lib/BloqadeLattices/src/visualize.jl
@@ -134,6 +134,8 @@ function img_atoms(
     xmin, ymin, xmax, ymax = LuxorGraphPlot.get_bounding_box(atoms)
     auto = config_plotting(atoms, xpad, ypad)
     config = LatticeDisplayConfig(; auto..., kwargs...)
+    # determine if you should use μm or um depending on Unicode support
+    config.axes_unit = UNICODE_ENABLED[] ? "μm" : "um"
     Dx, Dy = ((xmax-xmin)+2*auto.xpad)*config.scale*config.unit, ((ymax-ymin)+2*auto.ypad)*config.scale*config.unit
     transform(loc) = config.scale .* (loc[1]-xmin+auto.xpad, loc[2]-ymin+auto.ypad)
     LuxorGraphPlot._draw(Dx, Dy; format, filename) do

--- a/lib/BloqadeWaveforms/src/BloqadeWaveforms.jl
+++ b/lib/BloqadeWaveforms/src/BloqadeWaveforms.jl
@@ -10,6 +10,8 @@ using Optim: optimize,Brent
 using BloqadeExpr: default_unit
 using OrderedCollections: OrderedDict
 
+UNICODE_ENABLED = Ref(true)
+
 export Waveform,
     sample_values,
     sample_clock,

--- a/lib/BloqadeWaveforms/src/waveform.jl
+++ b/lib/BloqadeWaveforms/src/waveform.jl
@@ -196,6 +196,7 @@ function Base.show(io::IO, mime::MIME"text/plain", wf::Waveform)
         clocks,
         _rm_err.(sample_values(wf, clocks) ./ (2π));
         title = "Waveform{_, $(eltype(wf))}",
+        canvas = UNICODE_ENABLED[] ? UnicodePlots.BrailleCanvas : UnicodePlots.DotCanvas,
         # TODO: decide the unit?
         xlabel = "clock (μs)",
         ylabel = "value / 2π (MHz)",

--- a/src/Bloqade.jl
+++ b/src/Bloqade.jl
@@ -51,6 +51,16 @@ function __init__()
     return
 end
 
+function enable_unicode!()
+    BloqadeWaveforms.UNICODE_ENABLED[] = true
+    BloqadeLattices.UNICODE_ENABLED[] = true
+end
+
+function disable_unicode!()
+    BloqadeWaveforms.UNICODE_ENABLED[] = false
+    BloqadeLattices.UNICODE_ENABLED[] = false
+end
+
 using Colors, ColorSchemes
 
 include("plots/plots.jl")

--- a/src/plots/waveform.jl
+++ b/src/plots/waveform.jl
@@ -1,7 +1,7 @@
 function plot!(ax, wf::Waveform)
     clocks = sample_clock(wf)
     fig = ax.plot(clocks, BloqadeWaveforms._rm_err.(sample_values(wf, clocks) ./ (2π));)
-    ax.set_xlabel("time (μs)")
+    BloqadeWaveforms.UNICODE_ENABLED[] ? ax.set_xlabel("time (μs)") : ax.set_xlabel("time (us)")
     ax.set_ylabel("value / 2π (MHz)")
     return ax
 end


### PR DESCRIPTION
Built in response to #557 and some other cases where I've seen Bloqade output look non-ideal when Unicode support is spotty.

This creates a pair of functions `Bloqade.enable_unicode!()` and `Bloqade.disable_unicode!()` which will minimize/disable the amount of unicode used across the package when plotting things.

For command line plots, disabling unicode will cause UnicodePlots to use a `DotCanvas` which relies purely on the ASCII character set instead of Unicode.

For plots in notebooks, the "\mu" in the "microsecond" unit on axes has been replaced with a standard ASCII "u" although if this PR gets approval I'd like to expand that to replace the "\pi" with just "pi" before merging.