### PR TITLE
fix destats deprecation -> stats warning due to new version of OrdinaryDiffEq.jl

### DIFF
--- a/lib/BloqadeODE/src/integrator_init.jl
+++ b/lib/BloqadeODE/src/integrator_init.jl
@@ -432,7 +432,7 @@ function DiffEqBase.__init(
         stop_at_next_tstop,
     )
 
-    destats = DiffEqBase.DEStats(0)
+    stats = DiffEqBase.Stats(0)
 
     if typeof(_alg) <: OrdinaryDiffEqCompositeAlgorithm
         id = CompositeInterpolationData(f, timeseries, ts, ks, alg_choice, dense, cache)
@@ -446,7 +446,7 @@ function DiffEqBase.__init(
             interp = id,
             alg_choice = alg_choice,
             calculate_error = false,
-            destats = destats,
+            stats = stats,
         )
     else
         id = InterpolationData(f, timeseries, ts, ks, dense, cache)
@@ -459,7 +459,7 @@ function DiffEqBase.__init(
             k = ks,
             interp = id,
             calculate_error = false,
-            destats = destats,
+            stats = stats,
         )
     end
 
@@ -572,7 +572,7 @@ function DiffEqBase.__init(
         reinitiailize,
         isdae,
         opts,
-        destats,
+        stats,
         initializealg,
     )
 


### PR DESCRIPTION
[Summary]
This PR fix the BloqadeODE warning due to OrdinaryDiffEq.jl deprecate "destats" in new version.

[Issue that get fixed]
When interact with new version of OrdinaryDiffEq.jl, the following warning will pop up
```
┌ Warning: `destats` kwarg has been deprecated in favor of `stats`
│   caller = __init(prob::SchrodingerProblem{ArrayReg{2, ComplexF64, Matrix{ComplexF64}}, ODEFunction{true, SciMLBase.FullSpecialize, SchrodingerEquation{RydbergHamiltonian, BloqadeExpr.Hamiltonian{Tuple{BloqadeExpr.var"#80#114", BloqadeExpr.var"#82#116", typeof(one)}, Tuple{SparseMatrixCSC{ComplexF64, Int64}, SparseMatrixCSC{ComplexF64, Int64}, Diagonal{ComplexF64, Vector{ComplexF64}}}}}, LinearAlgebra.UniformScaling{Bool}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED), Nothing, Nothing}, Vector{ComplexF64}, Tuple{Float64, Float64}, DP8{typeof(OrdinaryDiffEq.trivial_limiter!), typeof(OrdinaryDiffEq.trivial_limiter!), Static.False}, Base.Pairs{Symbol, Real, NTuple{8, Symbol}, NamedTuple{(:save_everystep, :save_start, :save_on, :dense, :reltol, :abstol, :dt, :progress), Tuple{Bool, Bool, Bool, Bool, Float64, Float64, Float64, Bool}}}}, alg::Vern8{typeof(OrdinaryDiffEq.trivial_limiter!), typeof(OrdinaryDiffEq.trivial_limiter!), Static.False}, timeseries_init::Tuple{}, ts_init::Tuple{}, ks_init::Tuple{}, recompile::Type{Val{true}}; saveat::Tuple{}, tstops::Tuple{}, d_discontinuities::Tuple{}, save_idxs::Nothing, save_everystep::Bool, save_on::Bool, save_start::Bool, save_end::Nothing, callback::Nothing, dense::Bool, calck::Bool, dt::Float64, dtmin::Nothing, dtmax::Float64, force_dtmin::Bool, adaptive::Bool, gamma::Rational{Int64}, abstol::Float64, reltol::Float64, qmin::Rational{Int64}, qmax::Int64, qsteady_min::Int64, qsteady_max::Int64, beta1::Nothing, beta2::Nothing, qoldinit::Rational{Int64}, controller::Nothing, fullnormalize::Bool, failfactor::Int64, maxiters::Int64, internalnorm::typeof(DiffEqBase.ODE_DEFAULT_NORM), internalopnorm::typeof(LinearAlgebra.opnorm), isoutofdomain::typeof(DiffEqBase.ODE_DEFAULT_ISOUTOFDOMAIN), unstable_check::typeof(DiffEqBase.ODE_DEFAULT_UNSTABLE_CHECK), verbose::Bool, timeseries_errors::Bool, dense_errors::Bool, advance_to_tstop::Bool, stop_at_next_tstop::Bool, initialize_save::Bool, progress::Bool, progress_steps::Int64, progress_name::String, progress_message::typeof(DiffEqBase.ODE_DEFAULT_PROG_MESSAGE), userdata::Nothing, allow_extrapolation::Bool, initialize_integrator::Bool, initializealg::OrdinaryDiffEq.DefaultInit, kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}) at integrator_init.jl:453
└ @ BloqadeODE ~/Bloqade.jl/lib/BloqadeODE/src/integrator_init.jl:453

```