### PR TITLE
[BloqadeKrylov] New solvers using magnus expansion and its commutator free twin 

### DIFF
--- a/lib/BloqadeKrylov/Project.toml
+++ b/lib/BloqadeKrylov/Project.toml
@@ -11,6 +11,7 @@ Configurations = "5218b696-f38b-4ac9-8b61-a12ec717816d"
 ExponentialUtilities = "d4d017d3-3776-5f7e-afef-a10c40355c18"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 ProgressLogging = "33c8b6b6-d38a-422a-b730-caa89a2f386c"
+Yao = "5872b779-8223-5990-8dd0-5abbb0748c8c"
 YaoArrayRegister = "e600142f-9330-5003-8abb-0ebd767abc51"
 YaoSubspaceArrayReg = "bd27d05e-4ce1-5e79-84dd-c5d7d508ade2"
 

--- a/lib/BloqadeKrylov/src/BloqadeKrylov.jl
+++ b/lib/BloqadeKrylov/src/BloqadeKrylov.jl
@@ -10,13 +10,21 @@ using BloqadeExpr: Hamiltonian, StepHamiltonian
 using ExponentialUtilities
 using ProgressLogging
 
-export KrylovEvolution, emulate!, emulate_step!
+export emulate!, emulate_step!
+export KrylovEvolution, Magnus4Evolution, CFET42Evolution
+
 
 include("expmv.jl")
-include("emulate.jl")
+include("common.jl")
+include("krylov.jl")
+include("magnus.jl")
+include("cfet.jl")
+
 
 if VERSION < v"1.7"
     include("patch.jl")
 end
+
+
 
 end

--- a/lib/BloqadeKrylov/src/cfet.jl
+++ b/lib/BloqadeKrylov/src/cfet.jl
@@ -132,7 +132,7 @@ function emulate_step!(prob::CFET42Evolution, step::Int, clock::Real, duration::
     expmv!(-im*duration, Ω4, state; prob.options.tol) 
 
     # do we need this normalization? 
-    #=
+    
     if mod(step, prob.options.normalize_step) == 0
         normalize!(prob.reg)
     end
@@ -140,7 +140,7 @@ function emulate_step!(prob::CFET42Evolution, step::Int, clock::Real, duration::
     if prob.options.normalize_finally && step == length(prob.durations)
         normalize!(prob.reg)
     end
-    =#
+    
     return prob
 end
 

--- a/lib/BloqadeKrylov/src/cfet.jl
+++ b/lib/BloqadeKrylov/src/cfet.jl
@@ -106,7 +106,7 @@ function CFET42Evolution(reg::AbstractRegister, clocks, h; kw...)
     start_clock, durations = first(clocks), diff(clocks)
     
     ## checking if it is equal time:
-    if length(unique(durations)) != 1
+    if length(unique(round.(durations,digits = 14) ) ) != 1
         throw(ArgumentError("durations must be equal (time slice must be equal)"))
     end 
 

--- a/lib/BloqadeKrylov/src/cfet.jl
+++ b/lib/BloqadeKrylov/src/cfet.jl
@@ -1,0 +1,147 @@
+
+
+"""
+    struct CFET42Evolution
+        CFET42Evolution(reg::AbstractRegister, clocks, h; kw...)
+
+Create a `CFET42Evolution` object that describes a time evolution
+using commutation-free 4th order Magnus method with 2 exponentials.
+https://arxiv.org/pdf/1102.5071.pdf (eq.61) (also eq.38)
+
+
+# Arguments
+
+- `reg`: a register, should be a subtype of `AbstractRegister`.
+- `clocks`: the clocks of this time evolution at each step.
+- `h`: a hamiltonian expression.
+
+# Keyword Arguments
+
+- `progress`: show progress bar, default is `false`.
+- `progress_name`: progress bar name, default is `"emulating"`.
+- `normalize_step`: normalize the state every `normalize_step`.
+- `normalize_finally`: wether normalize the state in the end of evolution, default is `true`.
+- `tol`: tolerance of the Krylov-expmv evaluation method, default is `1e-7`
+
+# Examples
+
+The following is the simplest way of using `CFET42Evolution`
+via [`emulate!`](@ref). For more advanced usage, please refer
+to documentation page [Emulation](@ref emulation).
+
+```jldoctest
+julia> using Bloqade
+
+julia> r = zero_state(5)
+ArrayReg{2, ComplexF64, Array...}
+    active qudits: 5/5
+    nlevel: 2
+
+julia> atoms = [(i, ) for i in 1:5]
+5-element Vector{Tuple{Int64}}:
+ (1,)
+ (2,)
+ (3,)
+ (4,)
+ (5,)
+
+julia> h = rydberg_h(atoms; Ω=sin)
+nqubits: 5
++
+├─ [+] ∑ 5.42e6/|x_i-x_j|^6 n_i n_j
+└─ [+] Ω(t) ⋅ ∑ σ^x_i
+
+
+julia> prob = CFET42Evolution(r, 0.0:1e-2:0.1, h);
+
+julia> emulate!(prob); # run the emulation
+```
+"""
+struct CFET42Evolution{Reg<:AbstractRegister,T<:Real,H<:Hamiltonian} <: Evolver
+    reg::Reg
+    start_clock::T
+    durations::Vector{T}
+    hamiltonian::H
+    options::KrylovOptions
+
+    function CFET42Evolution{Reg,T,H}(reg, start_clock, durations, hamiltonian, options) where {Reg,T,H}
+        start_clock ≥ 0 || throw(ArgumentError("start clock must not be negative"))
+        all(≥(0), durations) || throw(ArgumentError("durations must not be negative"))
+        return new{Reg,T,H}(reg, start_clock, durations, hamiltonian, options)
+    end
+end
+
+"""
+    CFET42Evolution(reg, start_clock, durations, hamiltonian, options)
+
+Create a `CFET42Evolution` object.
+
+# Arguments
+
+- `reg`: a register object.
+- `start_clock`: start clock of the evolution.
+- `durations`: list of durations at each time step.
+- `hamiltonian`: low-level hamiltonian object of type [`Hamiltonian`](@ref).
+- `options`: options of the evolution in type [`KrylovOptions`](@ref).
+"""
+function CFET42Evolution(reg, start_clock, durations, hamiltonian, options)
+    return CFET42Evolution{typeof(reg),typeof(start_clock),typeof(hamiltonian)}(
+        reg,
+        start_clock,
+        durations,
+        hamiltonian,
+        options,
+    )
+end
+
+function Adapt.adapt_structure(to, x::CFET42Evolution)
+    return CFET42Evolution(adapt(to, x.reg), x.start_clock, x.durations, adapt(to, x.hamiltonian), x.options)
+end
+
+function CFET42Evolution(reg::AbstractRegister, clocks, h; kw...)
+    all(≥(0), clocks) || throw(ArgumentError("clocks must not be negative"))
+    options = from_kwargs(KrylovOptions; kw...)
+    P = real(eltype(statevec(reg)))
+    T = isreal(h) ? P : Complex{P}
+    start_clock, durations = first(clocks), diff(clocks)
+    
+    ## checking if it is equal time:
+    if length(unique(durations)) != 1
+        throw(ArgumentError("durations must be equal (time slice must be equal)"))
+    end 
+
+    return CFET42Evolution(reg, start_clock, durations, Hamiltonian(T, h, space(reg)), options)
+end
+
+function emulate_step!(prob::CFET42Evolution, step::Int, clock::Real, duration::Real)
+    state = statevec(prob.reg)
+    h = prob.hamiltonian
+
+    A1 = BloqadeExpr.to_matrix(h(clock + (0.5-√3/6)*duration))
+    A2 = BloqadeExpr.to_matrix(h(clock + (0.5+√3/6)*duration)) 
+    
+    s1 = (3 + 2*√3)/12
+    s2 = (3 - 2*√3)/12
+
+    # exp stage 1
+    Ω4 = s1*A1 + s2*A2
+    expmv!(-im*duration, Ω4, state; prob.options.tol) 
+
+    # exp stage 2
+    Ω4 = s2*A1 + s1*A2
+    expmv!(-im*duration, Ω4, state; prob.options.tol) 
+
+    # do we need this normalization? 
+    #=
+    if mod(step, prob.options.normalize_step) == 0
+        normalize!(prob.reg)
+    end
+
+    if prob.options.normalize_finally && step == length(prob.durations)
+        normalize!(prob.reg)
+    end
+    =#
+    return prob
+end
+
+

--- a/lib/BloqadeKrylov/src/common.jl
+++ b/lib/BloqadeKrylov/src/common.jl
@@ -91,3 +91,34 @@ function print_state_info(io::IO, prob::Evolver)
     printstyled(io, Base.format_bytes(storage_size(prob.reg)); color = :yellow)
     return println(io)
 end
+
+
+function uniquetol_list(itr::Array{T,1},tol=1e-6) where {T<:Complex}
+    preal = sortperm(real(itr))     # buffer for permutation idxs of reals
+    dreal = diff(real(itr[preal]))  # buffer for differences of reals
+
+    pimag = Array{Int}(size(preal))     # buffer for permutation idxs of imags
+    dimag = Array{Float64}(size(dreal)) # buffer for differences of imags
+
+    out = [ ];
+    pri1=1;
+    for pri2 = 1:length(preal)
+        # look for tol-wide gap in reals
+        if pri2==length(preal) || dreal[pri2] > tol
+            pridxs = preal[pri1:pri2]
+            sortperm!( pimag[1:length(pridxs)], imag(itr[pridxs]) )
+            dimag[1:(length(pridxs)-1)] = diff(imag(itr[preal[pridxs]]))
+
+            pii1=1;
+            for pii2 = 1:length(pridxs)
+                if pii2==length(pridxs) || dimag[pii2] > tol
+                    push!(out, Array{T,1}(itr[pridxs[pii1:pii2]]))
+                    pii1=pii2+1;
+                end # imag tol check
+            end # pii2, tol-large gap in imags
+
+            pri1=pri2+1;
+        end # real tol check
+    end # pri2, tol-large gap in reals
+    return out
+end

--- a/lib/BloqadeKrylov/src/common.jl
+++ b/lib/BloqadeKrylov/src/common.jl
@@ -1,0 +1,93 @@
+"""
+    struct KrylovOptions
+
+Krylov evolution options.
+"""
+@option struct KrylovOptions
+    progress::Bool = false
+    progress_step::Int = 1
+    progress_name::String = "emulating"
+    normalize_step::Int = 5
+    normalize_finally::Bool = true
+    tol::Float64 = 1e-7
+end
+
+## this is the abstract type for all evolvers 
+## KrylovEvolution, Magnus4Evolution, CFET42Evolution
+abstract type Evolver end
+
+
+
+# These are common parts shared by all the evolvers
+Base.length(prob::Evolver) = length(prob.durations) + 1
+
+function Base.iterate(prob::Evolver)
+    info = (; step = 1, reg = prob.reg, clock = prob.start_clock, duration = zero(prob.start_clock))
+    return info, (2, prob.start_clock)
+end
+
+Base.@propagate_inbounds function Base.iterate(prob::Evolver, (step, clock))
+    step > length(prob) && return
+
+    duration = prob.durations[step-1]
+    emulate_step!(prob, step, clock, duration)
+
+    info = (; step, reg = prob.reg, clock = clock + duration, duration)
+    return info, (step + 1, clock + duration)
+end
+
+## driver function, user entry point
+function BloqadeExpr.emulate!(prob::Evolver)
+    niterations = length(prob)
+    @inbounds if prob.options.progress
+        ProgressLogging.progress() do id
+            for info in prob
+                if prob.options.progress && mod(info.step, prob.options.progress_step) == 0
+                    @info prob.options.progress_name progress = info.step / niterations _id = id
+                end
+            end
+        end
+    else
+        for info in prob
+        end
+    end
+    return prob
+end
+
+tab(indent) = " "^indent
+
+function Base.show(io::IO, mime::MIME"text/plain", prob::Evolver)
+    indent = get(io, :indent, 0)
+    println(io, tab(indent), Base.typename(typeof(prob)).wrapper, ":")
+    # state info
+    print_state_info(io, prob)
+    println(io)
+
+    # clocks
+    println(io, tab(indent + 2), "clocks")
+    println(io, tab(indent + 4), "start:", prob.start_clock, "μs")
+    println(io, tab(indent + 4), " last:", prob.start_clock + sum(prob.durations), "μs")
+    println(io)
+
+    # equation info
+    show(IOContext(io, :indent => indent + 2), mime, prob.hamiltonian)
+    println(io)
+    println(io)
+
+    println(io, tab(indent + 2), "Options:")
+    for name in fieldnames(KrylovOptions)
+        println(io, tab(indent + 4), name, "=", repr(getfield(prob.options, name)))
+    end
+end
+
+function print_state_info(io::IO, prob::Evolver)
+    indent = get(io, :indent, 0)
+    println(io, tab(indent + 2), "register info:")
+    print(io, tab(indent + 4), "type: ")
+    printstyled(io, typeof(prob.reg); color = :green)
+    println(io)
+
+    print(io, tab(indent + 4), "storage size: ")
+    printstyled(io, Base.format_bytes(storage_size(prob.reg)); color = :yellow)
+    return println(io)
+end

--- a/lib/BloqadeKrylov/src/magnus.jl
+++ b/lib/BloqadeKrylov/src/magnus.jl
@@ -108,7 +108,7 @@ function Magnus4Evolution(reg::AbstractRegister, clocks, h; kw...)
     start_clock, durations = first(clocks), diff(clocks)
     
     ## checking if it is equal time:
-    if length(unique(durations)) != 1
+    if length(unique(round.(durations,digits = 14) ) )  != 1
         throw(ArgumentError("durations must be equal (time slice must be equal)"))
     end 
 

--- a/lib/BloqadeKrylov/src/magnus.jl
+++ b/lib/BloqadeKrylov/src/magnus.jl
@@ -115,10 +115,13 @@ function Magnus4Evolution(reg::AbstractRegister, clocks, h; kw...)
     return Magnus4Evolution(reg, start_clock, durations, Hamiltonian(T, h, space(reg)), options)
 end
 
+
+
+# simple version
 function emulate_step!(prob::Magnus4Evolution, step::Int, clock::Real, duration::Real)
     state = statevec(prob.reg)
     h = prob.hamiltonian
-
+    
     A1 = BloqadeExpr.to_matrix(h(clock + (0.5-√3/6)*duration))
     A2 = BloqadeExpr.to_matrix(h(clock + (0.5+√3/6)*duration)) 
     

--- a/lib/BloqadeKrylov/src/magnus.jl
+++ b/lib/BloqadeKrylov/src/magnus.jl
@@ -127,7 +127,7 @@ function emulate_step!(prob::Magnus4Evolution, step::Int, clock::Real, duration:
     expmv!(-im*duration, Ω4, state; prob.options.tol) 
 
     # do we need this normalization? 
-    #=
+    
     if mod(step, prob.options.normalize_step) == 0
         normalize!(prob.reg)
     end
@@ -135,7 +135,7 @@ function emulate_step!(prob::Magnus4Evolution, step::Int, clock::Real, duration:
     if prob.options.normalize_finally && step == length(prob.durations)
         normalize!(prob.reg)
     end
-    =#
+    
     return prob
 end
 

--- a/lib/BloqadeKrylov/src/magnus.jl
+++ b/lib/BloqadeKrylov/src/magnus.jl
@@ -1,0 +1,142 @@
+
+## TODO this does not explicity constrain the type yet, A&B have to be SparseMatrixCSR or LuxurySparse
+function commutator(A, B)
+    return A*B - B*A
+end 
+
+"""
+    struct Magnus4Evolution
+    Magnus4Evolution(reg::AbstractRegister, clocks, h; kw...)
+
+Create a `Magnus4Evolution` object that describes a time evolution
+using Magnus method with 4th order.
+
+# Arguments
+
+- `reg`: a register, should be a subtype of `AbstractRegister`.
+- `clocks`: the clocks of this time evolution at each step.
+- `h`: a hamiltonian expression.
+
+# Keyword Arguments
+
+- `progress`: show progress bar, default is `false`.
+- `progress_name`: progress bar name, default is `"emulating"`.
+- `normalize_step`: normalize the state every `normalize_step`.
+- `normalize_finally`: wether normalize the state in the end of evolution, default is `true`.
+- `tol`: tolerance of the Krylov-expmv evaluation method, default is `1e-7`
+
+# Examples
+
+The following is the simplest way of using `Magnus4Evolution`
+via [`emulate!`](@ref). For more advanced usage, please refer
+to documentation page [Emulation](@ref emulation).
+
+```jldoctest
+julia> using Bloqade
+
+julia> r = zero_state(5)
+ArrayReg{2, ComplexF64, Array...}
+    active qudits: 5/5
+    nlevel: 2
+
+julia> atoms = [(i, ) for i in 1:5]
+5-element Vector{Tuple{Int64}}:
+ (1,)
+ (2,)
+ (3,)
+ (4,)
+ (5,)
+
+julia> h = rydberg_h(atoms; Ω=sin)
+nqubits: 5
++
+├─ [+] ∑ 5.42e6/|x_i-x_j|^6 n_i n_j
+└─ [+] Ω(t) ⋅ ∑ σ^x_i
+
+
+julia> prob = Magnus4Evolution(r, 0.0:1e-2:0.1, h);
+
+julia> emulate!(prob); # run the emulation
+```
+"""
+struct Magnus4Evolution{Reg<:AbstractRegister,T<:Real,H<:Hamiltonian} <: Evolver
+    reg::Reg
+    start_clock::T
+    durations::Vector{T}
+    hamiltonian::H
+    options::KrylovOptions
+
+    function Magnus4Evolution{Reg,T,H}(reg, start_clock, durations, hamiltonian, options) where {Reg,T,H}
+        start_clock ≥ 0 || throw(ArgumentError("start clock must not be negative"))
+        all(≥(0), durations) || throw(ArgumentError("durations must not be negative"))
+        return new{Reg,T,H}(reg, start_clock, durations, hamiltonian, options)
+    end
+end
+
+"""
+    Magnus4Evolution(reg, start_clock, durations, hamiltonian, options)
+
+Create a `Magnus4Evolution` object.
+
+# Arguments
+
+- `reg`: a register object.
+- `start_clock`: start clock of the evolution.
+- `durations`: list of durations at each time step.
+- `hamiltonian`: low-level hamiltonian object of type [`Hamiltonian`](@ref).
+- `options`: options of the evolution in type [`KrylovOptions`](@ref).
+"""
+function Magnus4Evolution(reg, start_clock, durations, hamiltonian, options)
+    return Magnus4Evolution{typeof(reg),typeof(start_clock),typeof(hamiltonian)}(
+        reg,
+        start_clock,
+        durations,
+        hamiltonian,
+        options,
+    )
+end
+
+function Adapt.adapt_structure(to, x::Magnus4Evolution)
+    return Magnus4Evolution(adapt(to, x.reg), x.start_clock, x.durations, adapt(to, x.hamiltonian), x.options)
+end
+
+function Magnus4Evolution(reg::AbstractRegister, clocks, h; kw...)
+    all(≥(0), clocks) || throw(ArgumentError("clocks must not be negative"))
+    options = from_kwargs(KrylovOptions; kw...)
+    P = real(eltype(statevec(reg)))
+    T = isreal(h) ? P : Complex{P}
+    start_clock, durations = first(clocks), diff(clocks)
+    
+    ## checking if it is equal time:
+    if length(unique(durations)) != 1
+        throw(ArgumentError("durations must be equal (time slice must be equal)"))
+    end 
+
+    return Magnus4Evolution(reg, start_clock, durations, Hamiltonian(T, h, space(reg)), options)
+end
+
+function emulate_step!(prob::Magnus4Evolution, step::Int, clock::Real, duration::Real)
+    state = statevec(prob.reg)
+    h = prob.hamiltonian
+
+    A1 = BloqadeExpr.to_matrix(h(clock + (0.5-√3/6)*duration))
+    A2 = BloqadeExpr.to_matrix(h(clock + (0.5+√3/6)*duration)) 
+    
+    Ω4 = 0.5 * (A1 + A2) - duration*√3/12 * commutator(A1, A2)
+    
+    expmv!(-im*duration, Ω4, state; prob.options.tol) 
+
+    # do we need this normalization? 
+    #=
+    if mod(step, prob.options.normalize_step) == 0
+        normalize!(prob.reg)
+    end
+
+    if prob.options.normalize_finally && step == length(prob.durations)
+        normalize!(prob.reg)
+    end
+    =#
+    return prob
+end
+
+

--- a/lib/BloqadeKrylov/test/Project.toml
+++ b/lib/BloqadeKrylov/test/Project.toml
@@ -1,15 +1,16 @@
 [deps]
+BloqadeExpr = "bd27d05e-4ce1-5e79-84dd-c5d7d508abe2"
+BloqadeLattices = "bd27d05e-4ce1-5e79-84dd-c5d7d508bbe4"
+BloqadeODE = "bd27d05e-4ce1-5e79-84dd-c5d7d508bbe5"
+BloqadeWaveforms = "bd27d05e-4ce1-5e79-84dd-c5d7d508bbe7"
+ExponentialUtilities = "d4d017d3-3776-5f7e-afef-a10c40355c18"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Yao = "5872b779-8223-5990-8dd0-5abbb0748c8c"
 YaoArrayRegister = "e600142f-9330-5003-8abb-0ebd767abc51"
-BloqadeLattices = "bd27d05e-4ce1-5e79-84dd-c5d7d508bbe4"
-BloqadeWaveforms = "bd27d05e-4ce1-5e79-84dd-c5d7d508bbe7"
 YaoSubspaceArrayReg = "bd27d05e-4ce1-5e79-84dd-c5d7d508ade2"
-BloqadeExpr = "bd27d05e-4ce1-5e79-84dd-c5d7d508abe2"
-SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
-ExponentialUtilities = "d4d017d3-3776-5f7e-afef-a10c40355c18"
 
 [compat]
 ForwardDiff = "0.10.32"

--- a/lib/BloqadeKrylov/test/cfet42_sinX.jl
+++ b/lib/BloqadeKrylov/test/cfet42_sinX.jl
@@ -1,0 +1,38 @@
+using Test
+using BloqadeExpr
+using YaoArrayRegister
+using BloqadeWaveforms
+using BloqadeKrylov
+using BloqadeLattices
+using BloqadeExpr: Hamiltonian
+using BloqadeODE
+using Yao
+
+@testset "cfet42_sinX" begin
+
+    atoms = generate_sites(ChainLattice(), 1, scale = 1)
+    wf = Waveform(t->2.2*2π*sin(2π*t), duration = 1.3);
+    h = rydberg_h(atoms; Ω = wf)
+
+    ## do magnus4
+    reg = zero_state(length(atoms))
+    clocks = collect(0:1e-3:1.3)
+    prob = CFET42Evolution(reg, clocks, h)
+    show(stdout, MIME"text/plain"(), prob)
+    #@test_throws ArgumentError KrylovEvolution(reg, [-0.1, 0.1], h)
+    emulate!(prob)
+
+    
+    #benchmark against ODE solver:
+    odereg = zero_state(length(atoms))
+    ODEprob = SchrodingerProblem(odereg,1.3,h)
+    show(stdout, MIME"text/plain"(), ODEprob)
+    emulate!(ODEprob)
+
+    @test prob.reg.state ≈ ODEprob.reg.state 
+
+    prob = CFET42Evolution(reg, clocks, h)
+    for info in prob
+        @test info.clock == clocks[info.step]
+    end
+end

--- a/lib/BloqadeKrylov/test/krylov_sinX.jl
+++ b/lib/BloqadeKrylov/test/krylov_sinX.jl
@@ -1,0 +1,39 @@
+using Test
+using BloqadeExpr
+using YaoArrayRegister
+using BloqadeWaveforms
+using BloqadeKrylov
+using BloqadeLattices
+using BloqadeExpr: Hamiltonian
+using Yao
+
+@testset "krylov_sinX" begin
+
+    atoms = generate_sites(ChainLattice(), 1, scale = 1)
+    wf = Waveform(t->2.2*2π*sin(2π*t), duration = 1.3);
+    h = rydberg_h(atoms; Ω = wf)
+    reg = zero_state(length(atoms))
+    clocks = collect(0:1e-2:1.3)
+    prob = KrylovEvolution(reg, clocks, h)
+    show(stdout, MIME"text/plain"(), prob)
+    #@test_throws ArgumentError KrylovEvolution(reg, [-0.1, 0.1], h)
+    emulate!(prob)
+
+    hs = map(clocks[1:end-1]) do t
+        return Matrix(h |> attime(t))
+    end
+
+    r = zero_state(length(atoms))
+    state = statevec(r)
+    durations = diff(clocks)
+    for (t, h) in zip(durations, hs)
+        state = exp(-im * t * h) * state
+    end
+
+    @test state ≈ prob.reg.state
+
+    prob = KrylovEvolution(reg, clocks, h)
+    for info in prob
+        @test info.clock == clocks[info.step]
+    end
+end

--- a/lib/BloqadeKrylov/test/magnus4_sinX.jl
+++ b/lib/BloqadeKrylov/test/magnus4_sinX.jl
@@ -1,0 +1,38 @@
+using Test
+using BloqadeExpr
+using YaoArrayRegister
+using BloqadeWaveforms
+using BloqadeKrylov
+using BloqadeLattices
+using BloqadeExpr: Hamiltonian
+using BloqadeODE
+using Yao
+
+@testset "magnus4_sinX" begin
+
+    atoms = generate_sites(ChainLattice(), 1, scale = 1)
+    wf = Waveform(t->2.2*2π*sin(2π*t), duration = 1.3);
+    h = rydberg_h(atoms; Ω = wf)
+
+    ## do magnus4
+    reg = zero_state(length(atoms))
+    clocks = collect(0:1e-3:1.3)
+    prob = Magnus4Evolution(reg, clocks, h)
+    show(stdout, MIME"text/plain"(), prob)
+    #@test_throws ArgumentError KrylovEvolution(reg, [-0.1, 0.1], h)
+    emulate!(prob)
+
+    
+    #benchmark against ODE solver:
+    odereg = zero_state(length(atoms))
+    ODEprob = SchrodingerProblem(odereg,1.3,h)
+    show(stdout, MIME"text/plain"(), ODEprob)
+    emulate!(ODEprob)
+
+    @test prob.reg.state ≈ ODEprob.reg.state 
+
+    prob = Magnus4Evolution(reg, clocks, h)
+    for info in prob
+        @test info.clock == clocks[info.step]
+    end
+end

--- a/lib/BloqadeKrylov/test/runtests.jl
+++ b/lib/BloqadeKrylov/test/runtests.jl
@@ -11,7 +11,7 @@ end
 @testset "cfet42_sinX" begin
     include("cfet42_sinX.jl")
 end
-#=
+
 @testset "expmv" begin
     include("expmv.jl")
 end
@@ -33,4 +33,3 @@ end
 @testset "forwarddiff" begin
     include("forwarddiff.jl")
 end
-=#

--- a/lib/BloqadeKrylov/test/runtests.jl
+++ b/lib/BloqadeKrylov/test/runtests.jl
@@ -8,6 +8,10 @@ if "docstring" in ARGS
 end
 
 
+@testset "cfet42_sinX" begin
+    include("cfet42_sinX.jl")
+end
+#=
 @testset "expmv" begin
     include("expmv.jl")
 end
@@ -29,3 +33,4 @@ end
 @testset "forwarddiff" begin
     include("forwarddiff.jl")
 end
+=#

--- a/lib/BloqadeKrylov/test/runtests.jl
+++ b/lib/BloqadeKrylov/test/runtests.jl
@@ -1,10 +1,12 @@
 using Test
 using BloqadeKrylov
 
+
 if "docstring" in ARGS
     # include("docstrings.jl")
     exit()
 end
+
 
 @testset "expmv" begin
     include("expmv.jl")
@@ -13,6 +15,16 @@ end
 @testset "emulate" begin
     include("emulate.jl")
 end
+
+
+@testset "krylov_sinX" begin
+    include("krylov_sinX.jl")
+end
+
+@testset "magnus4_sinX" begin
+    include("magnus4_sinX.jl")
+end
+
 
 @testset "forwarddiff" begin
     include("forwarddiff.jl")


### PR DESCRIPTION
[Summary]
This PR include following change to BloqadeKrylov:

1. Adding new integrators **Magnus4Evolution** and **CFET42Evolution** in parallel with current existing **KrylovEvolution** 
   and serve as drop-in replacement options for end user. 

2. Add abstract type **Evolver** for all the Evolution integrators, and rearrange the organization of code files. 

3. Add single site `sin(t)X` testing case for all three integrators, benchmark correctness with BloqadeODE solvers. 




