### PR TITLE
Unicode plots for lattice positions

### DIFF
--- a/lib/BloqadeLattices/Project.toml
+++ b/lib/BloqadeLattices/Project.toml
@@ -7,6 +7,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LuxorGraphPlot = "1f49bdf2-22a7-4bc4-978b-948dc219fbbc"
 NearestNeighbors = "b8a86587-4115-5ab1-83bc-aa920d37bbce"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 
 [compat]
 LuxorGraphPlot = "0.1.4"

--- a/lib/BloqadeLattices/src/BloqadeLattices.jl
+++ b/lib/BloqadeLattices/src/BloqadeLattices.jl
@@ -3,6 +3,7 @@
 module BloqadeLattices
 
 using NearestNeighbors
+using UnicodePlots
 using StatsBase
 using LuxorGraphPlot
 using LuxorGraphPlot: Point

--- a/lib/BloqadeLattices/src/BloqadeLattices.jl
+++ b/lib/BloqadeLattices/src/BloqadeLattices.jl
@@ -66,4 +66,5 @@ include("interact.jl")
 include("neighbors.jl")
 include("visualize.jl")
 
+
 end

--- a/lib/BloqadeLattices/src/visualize.jl
+++ b/lib/BloqadeLattices/src/visualize.jl
@@ -383,3 +383,24 @@ function lighttheme!()
     DEFAULT_TEXT_COLOR[] = "#000000"
     #DEFAULT_NODE_COLOR[] = "#FFFFFF"
 end
+
+function Base.show(io::IO, mime::MIME"text/plain", atoms::AtomList)
+
+    # convert list of tuples into two separate lists
+    x = Float64[]
+    y = Float64[]
+    for coord in atoms
+        push!(x, coord[1])
+        push!(y, coord[2])
+    end
+
+    plt = scatterplot(
+        x, 
+        y, 
+        title = "Approximate Atom Positions",
+        xlabel = "μm", 
+        ylabel = "μm",
+        marker = :circle)
+
+    return show(io, mime, plt)
+end


### PR DESCRIPTION
Considering we already default to unicode plots for waveforms being displayed in the terminal I thought it would be nice to bring that to the lattice positions.

I chose the title "Approximate Atom Positions" considering that as the number of atoms increases some undesirable squashing/stretching happens (e.g., for a `SquareLattice()` with a large enough number of atoms there seems to be some variable spacing between atoms).

<details>
<summary>Honeycomb Lattice</summary>
<img width="502" alt="Screenshot 2023-06-15 at 8 02 59 PM" src="https://github.com/QuEraComputing/Bloqade.jl/assets/32608115/6969ed40-61a6-47f0-b0ce-a9bd291973a7">
</details>

<details>
<summary> Kagome Lattice </summary>
<img width="458" alt="Screenshot 2023-06-15 at 8 04 42 PM" src="https://github.com/QuEraComputing/Bloqade.jl/assets/32608115/bb8e41d4-5b87-493c-87ce-ace54a460582">
</details>

<details>
<summary> Square Lattice </summary>
<img width="460" alt="Screenshot 2023-06-15 at 8 13 44 PM" src="https://github.com/QuEraComputing/Bloqade.jl/assets/32608115/e75f417c-b8be-4586-9883-ad970fffc7d1">
</details>

<details>
<summary> Random Positioning </summary>
<img width="731" alt="Screenshot 2023-06-15 at 8 10 45 PM" src="https://github.com/QuEraComputing/Bloqade.jl/assets/32608115/323baafb-7ce9-468d-9116-09eb8ca319c0">
</details>

