### PR TITLE
Fix typo in lattice validation with us vs um

### DIFF
--- a/lib/BloqadeSchema/src/validate.jl
+++ b/lib/BloqadeSchema/src/validate.jl
@@ -105,7 +105,7 @@ function validate_lattice(positions,dc::DeviceCapabilities)
             sorted_sites = sort(sites)
             error_sites = join([site=>positions[site] for site in sorted_sites],", ")
             push!(violations,
-                "positions {$(error_sites)} violate y minimum value of $vertical_resolution μs"
+                "positions {$(error_sites)} violate y minimum value of $vertical_resolution μm"
             )
 
         end

--- a/lib/BloqadeSchema/test/validate.jl
+++ b/lib/BloqadeSchema/test/validate.jl
@@ -83,7 +83,7 @@ end
     atoms = [v_1,v_2]
     violations = validate_lattice(atoms,dc)
     @test violations == Set([
-        "positions {1 => $v_1, 2 => $v_2} violate y minimum value of $vertical_resolution μs",
+        "positions {1 => $v_1, 2 => $v_2} violate y minimum value of $vertical_resolution μm",
         "positions 1 => $v_1 and 2 => $v_2 are a distance of $radial_spacing μm apart which is $(message(<)) value of $radial_spacing_min μm",
     ])
 
@@ -96,7 +96,7 @@ end
     error_sites = join([site=>atoms[site] for site in [1,3,4]],", ")
     violations = validate_lattice(atoms,dc)
         
-    @test violations == Set(["positions {$(error_sites)} violate y minimum value of $vertical_resolution μs"])
+    @test violations == Set(["positions {$(error_sites)} violate y minimum value of $vertical_resolution μm"])
 
 
 end


### PR DESCRIPTION
A problem was encountered on the QuEra Slack where a user encounters a standard position validation error (atoms are closer than 4.0 micrometers) but the unit used is microseconds instead of micrometers due to a typo.

@cduck narrowed it down to validation and I am making this PR with the appropriate fix. 