### PR TITLE
Fix Failing BloqadeWaveforms Unit Tests

### DIFF
--- a/lib/BloqadeWaveforms/src/waveform.jl
+++ b/lib/BloqadeWaveforms/src/waveform.jl
@@ -302,7 +302,7 @@ struct PiecewiseLinear{T<:Real,Interp}
         length(clocks) == length(values) || throw(ArgumentError("clocks must have the same length as values"))
         T = promote_type(eltype(clocks), eltype(values))
         clocks = Vector{T}(clocks); values = Vector{T}(values);
-        interp = LinearInterpolation(clocks, values)
+        interp = linear_interpolation(clocks, values)
         return new{eltype(values),typeof(interp)}(clocks, values, interp)
     end
 end

--- a/lib/BloqadeWaveforms/test/interpolate.jl
+++ b/lib/BloqadeWaveforms/test/interpolate.jl
@@ -63,7 +63,6 @@ benchmark_func([1.0,-1.0,1.0])
         end
     
         wf = Waveform(t->t^2,2)
-    
         @test_logs (:warn,warn_msg) piecewise_linear_interpolate(wf;atol=-1e-5)
         @test_throws ErrorException piecewise_linear_interpolate(wf;min_step = 0.1)
         @test_throws ErrorException piecewise_linear_interpolate(wf;atol=0)
@@ -75,7 +74,6 @@ benchmark_func([1.0,-1.0,1.0])
         new_wf = piecewise_constant_interpolate(wf)
         @test wf == new_wf
 
-        step_msg = "Waveform step smaller than constraint."
         @test_logs (:warn,warn_msg) piecewise_constant_interpolate(wf;atol=-1e-2)
         @test_throws ErrorException piecewise_constant_interpolate(wf;atol=0)
         @test_throws ErrorException piecewise_constant_interpolate(wf;min_step=3.0)
@@ -88,8 +86,6 @@ end
     new_wf = piecewise_linear_interpolate(wf)
     @test wf == new_wf
     
-    slope_msg = "Waveform slope larger than constraint."
-    step_msg = "Waveform step smaller than constraint."
     # test_log instead of test_warn for julia 1.6
     @test_logs (:warn,warn_msg) piecewise_linear_interpolate(wf;atol=-1e-3)
     @test_throws ErrorException piecewise_linear_interpolate(wf;atol=0)
@@ -100,8 +96,6 @@ end
 
 @testset "piecewise constant waveforms" begin
     wf = piecewise_constant(;clocks = [0.0, 2.0, 3.0, 4.0], values = [0.0, 2.0, 1.0])
-
-    pwc_step_msg = "Distance between steps in piecewise constant waveform are too small to convert to piecewise linear."
 
     new_wf = piecewise_linear_interpolate(wf,atol=1e-3) # no constraints
     @test new_wf == piecewise_linear(


### PR DESCRIPTION
The current failure seems to be from the fact we attempt to check for one warning message but the macro gets two of them from the fact that `LinearInterpolation` now issues a warning to migrate to `linear_interpolation`.

I've also gone ahead and removed some old local variables that were not being used at all in the `@test` scopes