### PR TITLE
Account for edge case where you only have single x value in coordinate

### DIFF
--- a/lib/BloqadeLattices/src/visualize.jl
+++ b/lib/BloqadeLattices/src/visualize.jl
@@ -392,7 +392,15 @@ function Base.show(io::IO, mime::MIME"text/plain", atoms::AtomList)
     y = Float64[]
     for coord in atoms
         push!(x, coord[1])
-        push!(y, coord[2])
+        
+        # Could be the case that coordinate only has single x value
+        # in which case we set the y value to 0
+        if length(coord) == 1
+            push!(y, 0)
+        else
+            push!(y, coord[2])
+        end
+
     end
 
     plt = scatterplot(

--- a/lib/BloqadeLattices/test/visualize.jl
+++ b/lib/BloqadeLattices/test/visualize.jl
@@ -3,7 +3,7 @@ using BloqadeLattices
 using LuxorGraphPlot
 using Documenter
 
-@testset "visualize" begin
+@testset "visualize (image)" begin
     BloqadeLattices.darktheme!()
     lt = generate_sites(KagomeLattice(), 5, 5, scale = 1.5)
     blt = parallelepiped_region(KagomeLattice(), (5,0),(0,5);scale=1.5)
@@ -28,4 +28,19 @@ using Documenter
     BloqadeLattices.lighttheme!()
     @test img_atoms(lt; colors = nothing) isa LuxorGraphPlot.Drawing
     @test show(IOBuffer(), MIME"image/svg+xml"(), lt) === nothing
+end
+
+
+@testset "visualize (text)" begin
+
+    @testset "single x value" begin
+        lt = generate_sites(ChainLattice(), 10, scale=5.74)
+        show(stdout, MIME"text/plain"(), lt)
+    end 
+
+    @testset "x and y values" begin
+        lt = generate_sites(SquareLattice(), 5, 5, scale=5.74)
+        show(stdout, MIME"text/plain"(), lt)
+    end
+
 end


### PR DESCRIPTION
Should fix #655 , a new release of `BloqadeLattices` will be necessary along with `Bloqade` to let users have access to this.