### PR TITLE
Bump BloqadeLattices to 0.2.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Bloqade"
 uuid = "bd27d05e-4ce1-5e79-84dd-c5d7d508bbe1"
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 BloqadeExpr = "bd27d05e-4ce1-5e79-84dd-c5d7d508abe2"
@@ -21,7 +21,7 @@ YaoSubspaceArrayReg = "bd27d05e-4ce1-5e79-84dd-c5d7d508ade2"
 [compat]
 BloqadeExpr = "0.2"
 BloqadeKrylov = "0.2"
-BloqadeLattices = "0.2"
+BloqadeLattices = "0.2.1"
 BloqadeMIS = "0.2"
 BloqadeODE = "0.2"
 BloqadeWaveforms = "0.2"

--- a/lib/BloqadeLattices/Project.toml
+++ b/lib/BloqadeLattices/Project.toml
@@ -1,6 +1,6 @@
 name = "BloqadeLattices"
 uuid = "bd27d05e-4ce1-5e79-84dd-c5d7d508bbe4"
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"


### PR DESCRIPTION
Allow users to have pretty printing fix that resolves #655 