### PR TITLE
Fix function syntax in waveform.jl docs

### DIFF
--- a/lib/BloqadeWaveforms/src/waveform.jl
+++ b/lib/BloqadeWaveforms/src/waveform.jl
@@ -655,4 +655,4 @@ julia> wf[0.9..1.5]
 ```
 
 """
-function (..) end
+function .. end


### PR DESCRIPTION
Previously this declared an anonymous function of one argument (..), then documented the argument `..` a global variable.

```
julia> function (f) end
#3 (generic function with 1 method)
```