### PR TITLE
Necessary changes for Metal ODE

### DIFF
--- a/lib/BloqadeLattices/src/lattice.jl
+++ b/lib/BloqadeLattices/src/lattice.jl
@@ -104,7 +104,7 @@ The vectors are defined as:
 - 𝐚₁ = (1.0, 0.0)
 - 𝐚₂ = (0.5, 0.5√3)
 """
-lattice_vectors(::HoneycombLattice) = ((1.0, 0.0), (0.5, 0.5 * sqrt(3)))
+lattice_vectors(::HoneycombLattice) = ((1.0f0, 0.0f0), (0.5f0, 0.5f0 * sqrt(3f0))) # force this to Float32 to use Metal (potential probelm if you care about precision)
 
 """
     lattice_sites(::HoneycombLattice)
@@ -116,7 +116,7 @@ The sites are defined as:
 - (0.0, 0.0)
 - (0.5, 0.5√3)
 """
-lattice_sites(::HoneycombLattice) = ((0.0, 0.0), (0.5, 0.5 / sqrt(3)))
+lattice_sites(::HoneycombLattice) = ((0.0f0, 0.0f0), (0.5f0, 0.5f0 / sqrt(3f0))) # force this to Float32 to use Metal (potential probelm if you care about precision)
 
 """
     struct SquareLattice <: AbstractLattice{2}
@@ -155,7 +155,7 @@ The vectors are defined as:
 - 𝐚₁ = (1.0, 0.0)
 - 𝐚₂ = (0.0, 1.0)
 """
-lattice_vectors(::SquareLattice) = ((1.0, 0.0), (0.0, 1.0))
+lattice_vectors(::SquareLattice) = ((1.0f0, 0.0f0), (0.0f0, 1.0f0))
 
 """
     lattice_sites(::SquareLattice)
@@ -166,7 +166,7 @@ floats.
 The sites are defined as:
 - (0.0, 0.0)
 """
-lattice_sites(::SquareLattice) = ((0.0, 0.0),)
+lattice_sites(::SquareLattice) = ((0.0f0, 0.0f0),)
 
 """
     struct TriangularLattice <: AbstractLattice{2}
@@ -205,7 +205,7 @@ The vectors are defined as:
 - 𝐚₁ = (1.0, 0.0)
 - 𝐚₂ = (0.5, 0.5√3)
 """
-lattice_vectors(::TriangularLattice) = ((1.0, 0.0), (0.5, 0.5 * sqrt(3)))
+lattice_vectors(::TriangularLattice) = ((1.0f0, 0.0f0), (0.5f0, 0.5f0 * sqrt(3f0))) # force this to Float32 to use Metal (potential probelm if you care about precision)
 
 """
     lattice_sites(::TriangularLattice)
@@ -216,7 +216,7 @@ floats.
 The sites are defined as:
 - (0.0, 0.0)
 """
-lattice_sites(::TriangularLattice) = ((0.0, 0.0),)
+lattice_sites(::TriangularLattice) = ((0.0f0, 0.0f0),)
 
 """
     struct ChainLattice <: AbstractLattice{1}
@@ -253,7 +253,7 @@ floats.
 The vectors are defined as:
 - 𝐚₁ = (1.0,)
 """
-lattice_vectors(::ChainLattice) = ((1.0,),)
+lattice_vectors(::ChainLattice) = ((1.0f0,),)
 
 """
     lattice_sites(::ChainLattice)
@@ -264,7 +264,7 @@ floats.
 The sites are defined as:
 - (0.0,)
 """
-lattice_sites(::ChainLattice) = ((0.0,),)
+lattice_sites(::ChainLattice) = ((0.0f0,),)
 
 """
     struct LiebLattice <: AbstractLattice{2}
@@ -302,7 +302,7 @@ The vectors are defined as:
 - 𝐚₁ = (1.0, 0.0)
 - 𝐚₂ = (0.0, 1.0)
 """
-lattice_vectors(::LiebLattice) = ((1.0, 0.0), (0.0, 1.0))
+lattice_vectors(::LiebLattice) = ((1.0f0, 0.0f0), (0.0f0, 1.0f0))
 
 """
     lattice_sites(::LiebLattice)
@@ -315,7 +315,7 @@ The sites are defined as:
 - (0.5, 0.0)
 - (0.0, 0.5)
 """
-lattice_sites(::LiebLattice) = ((0.0, 0.0), (0.5, 0.0), (0.0, 0.5))
+lattice_sites(::LiebLattice) = ((0.0f0, 0.0f0), (0.5f0, 0.0f0), (0.0f0, 0.5f0))
 
 """
     struct KagomeLattice <: AbstractLattice{2}
@@ -353,7 +353,7 @@ The vectors are defined as:
 - 𝐚₁ = (1.0, 0.0)
 - 𝐚₂ = (0.5, 0.5√3)
 """
-lattice_vectors(::KagomeLattice) = ((1.0, 0.0), (0.5, 0.5 * sqrt(3)))
+lattice_vectors(::KagomeLattice) = ((1.0f0, 0.0f0), (0.5f0, 0.5f0 * sqrt(3f0))) # force this to Float32 to use Metal (potential probelm if you care about precision)
 
 """
     lattice_sites(::KagomeLattice)
@@ -366,7 +366,7 @@ The sites are defined as:
 - (0.25, 0.25√3)
 - (0.75, 0.25√3)
 """
-lattice_sites(::KagomeLattice) = ((0.0, 0.0), (0.25, 0.25 * sqrt(3)), (0.75, 0.25 * sqrt(3)))
+lattice_sites(::KagomeLattice) = ((0.0f0, 0.0f0), (0.25f0, 0.25f0 * sqrt(3f0)), (0.75f0, 0.25f0 * sqrt(3f0))) # force this to Float32 to use Metal (potential probelm if you care about precision)
 
 """
     struct RectangularLattice <: AbstractLattice{2}
@@ -394,7 +394,7 @@ Overriden functions to return lattice vectors and sites exists as
 [`lattice_sites(::RectangularLattice)`](@ref).
 """
 struct RectangularLattice <: AbstractLattice{2}
-    aspect_ratio::Float64
+    aspect_ratio::Float32
 end
 
 """
@@ -405,9 +405,9 @@ floats.
         
 The vectors are defined as:
 - 𝐚₁ = (1.0, 0.0)
-- 𝐚₂ = (0.0, `r.aspect_ratio`), where `aspect_ratio` is a `Float64`.
+- 𝐚₂ = (0.0, `r.aspect_ratio`), where `aspect_ratio` is a `Float32`.
 """
-lattice_vectors(r::RectangularLattice) = ((1.0, 0.0), (0.0, r.aspect_ratio))
+lattice_vectors(r::RectangularLattice) = ((1.0f0, 0.0f0), (0.0f0, r.aspect_ratio)) # force this to Float32 to use Metal (potential probelm if you care about precision)
 
 """
     lattice_sites(::RectangularLattice)
@@ -418,7 +418,7 @@ floats.
 The sites are defined as:
 - (0.0, 0.0)
 """
-lattice_sites(::RectangularLattice) = ((0.0, 0.0),)
+lattice_sites(::RectangularLattice) = ((0.0f0, 0.0f0),)
 
 """
     AtomList{D, T} <: AbstractVector{NTuple{D, T}}

--- a/lib/BloqadeODE/src/problem.jl
+++ b/lib/BloqadeODE/src/problem.jl
@@ -97,8 +97,8 @@ function SchrodingerProblem(reg::AbstractRegister, tspan, expr; algo=DP8(), kw..
         save_start = false,
         save_on = false,
         dense = false,
-        reltol=1e-10,
-        abstol=1e-10,
+        reltol=1f-10,
+        abstol=1f-10,
         alias = ODEAliasSpecifier(alias_u0 = true)
     )
     kw = pairs(merge(default_ode_options, kw))


### PR DESCRIPTION
I made changes necessary for Metal in BloqadeLattices.jl. Basically, I replaced Float64 to Float32. But I do not know if that is what you want in other cases. 

In any case, with these changes, the following code runs, and it is identical to CUDA. 

```
    nsites = 5
    total_time = 3.0
    Ω_max = 2π * 4
    Ω = piecewise_linear(clocks = Float32[0.0, 0.1, 2.1, 2.2, total_time], values = Float32[0.0, Ω_max, Ω_max, 0, 0])
    U1 = -2π * 10
    U2 = 2π * 10
    Δ = piecewise_linear(clocks = Float32[0.0, 0.6, 2.1, total_time], values = Float32[U1, U1, U2, U2])
    atoms = generate_sites(ChainLattice(), nsites, scale = 5.72f0)
    h = rydberg_h(atoms; Δ, Ω)
    reg = zero_state(ComplexF32,nsites)
    prob = SchrodingerProblem(reg, Float32(total_time), h)
    
    # CPU
    @time emulate!(prob)
    
    # GPU
    d_prob = adapt(MtlArray, prob)
    Metal.@time emulate!(d_prob)

    @test Array(d_prob.reg.state) ≈ prob.reg.state
```

The output is the following:
```
7.850521 seconds (14.94 M allocations: 785.406 MiB, 87.07% gc time)
730.701813 seconds (819.48 M CPU allocations: 28.770 GiB, 17.59% gc time) (32.09 M GPU allocations: 1.053 GiB, 23.30% memmgmt time)
Test Summary: | Pass  Total      Time
ODE solver    |    1      1  12m18.6s
Test.DefaultTestSet("ODE solver", Any[], 1, false, false, true, 1.775809874817266e9, 1.77581061339946e9, false, "/Users/ayakausui/projects/Bloqade.jl/lib/BloqadeMetal/test/ode.jl", Random.Xoshiro(0x86fb2f620f107813, 0x3a790afe705089d1, 0xcc61645022da46ad, 0x1db951bdfe1b4ffa, 0x045e82200104a6bd))
```

The GPU version is much slower, but it seems to run. But this test is weird. Why do you use adapt for GPU array after emulation on CPU? When I moved adapt before the emulation on CPU, the GPU result became different, and the test failed. 

So I wonder what happens on the CUDA version and specifically whether the test passes when adapt is performed before the emulation on CPU. 

cc: @leios